### PR TITLE
Add shared permission helper for navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import CustomerOrder from './pages/CustomerOrder';
 import SiteEditor from './pages/SiteEditor';
 import Takeaway from './pages/Takeaway'; // Importation de la nouvelle page
 import { useRestaurantData } from './hooks/useRestaurantData';
+import { getDefaultPath, getPermissionLevel } from './services/navigation';
 
 const AppRoutes: React.FC = () => {
     const { currentUserRole } = useRestaurantData();
@@ -31,29 +32,22 @@ const AppRoutes: React.FC = () => {
 
     const { permissions } = currentUserRole;
 
-    // Aide pour déterminer la page par défaut en fonction des permissions
-    const getDefaultPath = () => {
-        if (permissions['/'] !== 'none') return '/';
-        if (permissions['/ventes'] !== 'none') return '/ventes';
-        if (permissions['/cocina'] !== 'none') return '/cocina';
-        // Ajouter d'autres solutions de repli si nécessaire
-        return '/login'; // Ne devrait pas se produire si connecté
-    };
+    const defaultPath = getDefaultPath(permissions);
 
     return (
         <Routes>
-            {permissions['/'] !== 'none' && <Route path="/" element={<Dashboard />} />}
-            {permissions['/ingredients'] !== 'none' && <Route path="/ingredients" element={<Ingredients />} />}
-            {permissions['/produits'] !== 'none' && <Route path="/produits" element={<Products />} />}
-            {permissions['/ventes'] !== 'none' && <Route path="/ventes" element={<FloorPlan />} />}
-            {permissions['/commande/:tableId'] !== 'none' && <Route path="/commande/:tableId" element={<Order />} />}
-            {permissions['/historique'] !== 'none' && <Route path="/historique" element={<History />} />}
-            {permissions['/rapports'] !== 'none' && <Route path="/rapports" element={<Reports />} />}
-            {permissions['/cocina'] !== 'none' && <Route path="/cocina" element={<Kitchen />} />}
-            {permissions['/site-editor'] === 'editor' && <Route path="/site-editor" element={<SiteEditor />} />}
-            {permissions['/para-llevar'] !== 'none' && <Route path="/para-llevar" element={<Takeaway />} />}
-            
-            <Route path="*" element={<Navigate to={getDefaultPath()} replace />} />
+            {getPermissionLevel(permissions, '/') !== 'none' && <Route path="/" element={<Dashboard />} />}
+            {getPermissionLevel(permissions, '/ingredients') !== 'none' && <Route path="/ingredients" element={<Ingredients />} />}
+            {getPermissionLevel(permissions, '/produits') !== 'none' && <Route path="/produits" element={<Products />} />}
+            {getPermissionLevel(permissions, '/ventes') !== 'none' && <Route path="/ventes" element={<FloorPlan />} />}
+            {getPermissionLevel(permissions, '/commande/:tableId') !== 'none' && <Route path="/commande/:tableId" element={<Order />} />}
+            {getPermissionLevel(permissions, '/historique') !== 'none' && <Route path="/historique" element={<History />} />}
+            {getPermissionLevel(permissions, '/rapports') !== 'none' && <Route path="/rapports" element={<Reports />} />}
+            {getPermissionLevel(permissions, '/cocina') !== 'none' && <Route path="/cocina" element={<Kitchen />} />}
+            {getPermissionLevel(permissions, '/site-editor') === 'editor' && <Route path="/site-editor" element={<SiteEditor />} />}
+            {getPermissionLevel(permissions, '/para-llevar') !== 'none' && <Route path="/para-llevar" element={<Takeaway />} />}
+
+            <Route path="*" element={<Navigate to={defaultPath} replace />} />
         </Routes>
     );
 };

--- a/components/LoginModal.tsx
+++ b/components/LoginModal.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useRestaurantData } from '../hooks/useRestaurantData';
 import { ChefHat, LogIn, X } from 'lucide-react';
 import Card from './ui/Card';
+import { getDefaultPath } from '../services/navigation';
 
 interface LoginModalProps {
     isOpen: boolean;
@@ -74,10 +75,8 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
                 onClose(); // Fermer le modal en cas de succès
                 // Naviguer vers la page appropriée
                 const { permissions } = role;
-                if (permissions['/'] !== 'none') navigate('/');
-                else if (permissions['/ventes'] !== 'none') navigate('/ventes');
-                else if (permissions['/cocina'] !== 'none') navigate('/cocina');
-                else navigate('/'); // Fallback
+                const destination = getDefaultPath(permissions, '/');
+                navigate(destination);
             } else {
                 setError('PIN incorrecto. Inténtelo de nuevo.');
                 setPin(Array(6).fill(''));

--- a/services/navigation.ts
+++ b/services/navigation.ts
@@ -1,0 +1,23 @@
+import { PagePermissions, PermissionLevel } from '../types';
+
+export const getPermissionLevel = (
+    permissions: Partial<PagePermissions> | undefined,
+    path: string
+): PermissionLevel => {
+    if (!permissions) {
+        return 'none';
+    }
+
+    return permissions[path] ?? 'none';
+};
+
+export const getDefaultPath = (
+    permissions: Partial<PagePermissions> | undefined,
+    fallback: string = '/login'
+): string => {
+    if (getPermissionLevel(permissions, '/') !== 'none') return '/';
+    if (getPermissionLevel(permissions, '/ventes') !== 'none') return '/ventes';
+    if (getPermissionLevel(permissions, '/cocina') !== 'none') return '/cocina';
+
+    return fallback;
+};


### PR DESCRIPTION
## Summary
- add a shared navigation helper that returns `none` when a permission is missing
- use the helper in the router and login modal to keep permission checks consistent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ce8be19af0832a8fa60d14a77048e3