### PR TITLE
Add helper to resolve default app route

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import CustomerOrder from './pages/CustomerOrder';
 import SiteEditor from './pages/SiteEditor';
 import Takeaway from './pages/Takeaway'; // Importation de la nouvelle page
 import { useRestaurantData } from './hooks/useRestaurantData';
+import { resolveDefaultRoute } from './appRoutes';
 
 const AppRoutes: React.FC = () => {
     const { currentUserRole } = useRestaurantData();
@@ -31,14 +32,7 @@ const AppRoutes: React.FC = () => {
 
     const { permissions } = currentUserRole;
 
-    // Aide pour déterminer la page par défaut en fonction des permissions
-    const getDefaultPath = () => {
-        if (permissions['/'] !== 'none') return '/';
-        if (permissions['/ventes'] !== 'none') return '/ventes';
-        if (permissions['/cocina'] !== 'none') return '/cocina';
-        // Ajouter d'autres solutions de repli si nécessaire
-        return '/login'; // Ne devrait pas se produire si connecté
-    };
+    const getDefaultPath = () => resolveDefaultRoute(permissions);
 
     return (
         <Routes>

--- a/appRoutes.ts
+++ b/appRoutes.ts
@@ -1,0 +1,35 @@
+import type { PagePermissions, PermissionLevel } from './types';
+
+export const APP_ROUTE_ORDER = [
+    '/',
+    '/ingredients',
+    '/produits',
+    '/ventes',
+    '/para-llevar',
+    '/cocina',
+    '/historique',
+    '/rapports',
+    '/site-editor',
+] as const;
+
+const hasRouteAccess = (path: string, level: PermissionLevel | undefined): boolean => {
+    if (path === '/site-editor') {
+        return level === 'editor';
+    }
+
+    return level === 'editor' || level === 'readonly';
+};
+
+export const resolveDefaultRoute = (permissions?: PagePermissions | null): string => {
+    if (!permissions) {
+        return '/login';
+    }
+
+    for (const path of APP_ROUTE_ORDER) {
+        if (hasRouteAccess(path, permissions[path])) {
+            return path;
+        }
+    }
+
+    return '/login';
+};

--- a/components/LoginModal.tsx
+++ b/components/LoginModal.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useRestaurantData } from '../hooks/useRestaurantData';
 import { ChefHat, LogIn, X } from 'lucide-react';
 import Card from './ui/Card';
+import { resolveDefaultRoute } from '../appRoutes';
 
 interface LoginModalProps {
     isOpen: boolean;
@@ -73,11 +74,8 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
             if (role) {
                 onClose(); // Fermer le modal en cas de succès
                 // Naviguer vers la page appropriée
-                const { permissions } = role;
-                if (permissions['/'] !== 'none') navigate('/');
-                else if (permissions['/ventes'] !== 'none') navigate('/ventes');
-                else if (permissions['/cocina'] !== 'none') navigate('/cocina');
-                else navigate('/'); // Fallback
+                const defaultRoute = resolveDefaultRoute(role.permissions);
+                navigate(defaultRoute);
             } else {
                 setError('PIN incorrecto. Inténtelo de nuevo.');
                 setPin(Array(6).fill(''));

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -9,6 +9,7 @@ import OrderHistoryModal from '../components/OrderHistoryModal';
 import { customerOrderHistoryService } from '../services/customerOrderHistoryService';
 import type { HistoricCommande } from '../types';
 import Section from '../components/ui/Section';
+import { resolveDefaultRoute } from '../appRoutes';
 
 const formatCOP = (value: number) => new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(Math.round(value));
 
@@ -40,7 +41,7 @@ const MesCommandes: React.FC<{
 
 
 const Login: React.FC = () => {
-    const { userRole, siteAssets, loading } = useRestaurantData();
+    const { currentUserRole, siteAssets, loading } = useRestaurantData();
     const navigate = useNavigate();
     const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
     const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -53,8 +54,13 @@ const Login: React.FC = () => {
         : siteAssets;
 
     useEffect(() => {
-        if (userRole) navigate('/');
-    }, [userRole, navigate]);
+        if (!currentUserRole) return;
+
+        const destination = resolveDefaultRoute(currentUserRole.permissions);
+        if (destination !== '/login') {
+            navigate(destination);
+        }
+    }, [currentUserRole, navigate]);
 
     const loadHistory = useCallback(() => {
         setOrderHistory(customerOrderHistoryService.getHistory());


### PR DESCRIPTION
## Summary
- add a shared helper that determines the first accessible application route for a role
- reuse the helper in App routing, the login modal, and the public login page to unify post-login navigation logic

## Testing
- npm run build
- Manual validation: log in with the cocina PIN (004799) and confirm the app redirects to the ingredients page

------
https://chatgpt.com/codex/tasks/task_b_68ce8bccf390832aadf57f889f7d23b6