### PR TITLE
feat: add Supabase-backed auth and roles functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 dist/
 .env.local
 .env
+
+# Local Netlify folder
+.netlify

--- a/netlify/functions/auth-login.ts
+++ b/netlify/functions/auth-login.ts
@@ -1,0 +1,77 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Role } from '../../types';
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SERVICE_KEY ?? process.env.SUPABASE_SERVICE_API_KEY;
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response =>
+    new Response(JSON.stringify(body), {
+        headers: { 'Content-Type': 'application/json' },
+        ...init,
+    });
+
+const createSupabaseClient = () => {
+    if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+        throw new Error('Supabase service credentials are not configured.');
+    }
+    return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+        auth: {
+            persistSession: false,
+        },
+    });
+};
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return jsonResponse(
+            { message: 'Method Not Allowed' },
+            {
+                status: 405,
+                headers: {
+                    Allow: 'POST',
+                    'Content-Type': 'application/json',
+                },
+            }
+        );
+    }
+
+    let pin: unknown;
+    try {
+        const payload = await request.json();
+        pin = payload?.pin;
+    } catch (error) {
+        console.error('auth-login: failed to parse request body', error);
+        return jsonResponse({ message: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    if (typeof pin !== 'string' || pin.trim().length === 0) {
+        return jsonResponse({ message: 'PIN is required' }, { status: 400 });
+    }
+
+    let supabase;
+    try {
+        supabase = createSupabaseClient();
+    } catch (error) {
+        console.error('auth-login: Supabase configuration error', error);
+        return jsonResponse({ message: 'Server configuration error' }, { status: 500 });
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from<Role>('roles')
+            .select('*')
+            .eq('pin', pin)
+            .maybeSingle();
+
+        if (error) {
+            console.error('auth-login: Supabase query error', error);
+            return jsonResponse({ message: 'Unable to complete authentication' }, { status: 500 });
+        }
+
+        return jsonResponse(data ?? null);
+    } catch (error) {
+        console.error('auth-login: unexpected error', error);
+        return jsonResponse({ message: 'Unexpected server error' }, { status: 500 });
+    }
+}

--- a/netlify/functions/roles.ts
+++ b/netlify/functions/roles.ts
@@ -1,0 +1,78 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Role } from '../../types';
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SERVICE_KEY ?? process.env.SUPABASE_SERVICE_API_KEY;
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response =>
+    new Response(JSON.stringify(body), {
+        headers: { 'Content-Type': 'application/json' },
+        ...init,
+    });
+
+const createSupabaseClient = () => {
+    if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+        throw new Error('Supabase service credentials are not configured.');
+    }
+    return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+        auth: {
+            persistSession: false,
+        },
+    });
+};
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'GET') {
+        return jsonResponse(
+            { message: 'Method Not Allowed' },
+            {
+                status: 405,
+                headers: {
+                    Allow: 'GET',
+                    'Content-Type': 'application/json',
+                },
+            }
+        );
+    }
+
+    let supabase;
+    try {
+        supabase = createSupabaseClient();
+    } catch (error) {
+        console.error('roles: Supabase configuration error', error);
+        return jsonResponse({ message: 'Server configuration error' }, { status: 500 });
+    }
+
+    const url = new URL(request.url);
+    const pin = url.searchParams.get('pin');
+
+    try {
+        if (pin) {
+            const { data, error } = await supabase
+                .from<Role>('roles')
+                .select('*')
+                .eq('pin', pin)
+                .maybeSingle();
+
+            if (error) {
+                console.error('roles: Supabase query error (pin filter)', error);
+                return jsonResponse({ message: 'Unable to retrieve role' }, { status: 500 });
+            }
+
+            return jsonResponse(data ?? null);
+        }
+
+        const { data, error } = await supabase.from<Role>('roles').select('*');
+
+        if (error) {
+            console.error('roles: Supabase query error', error);
+            return jsonResponse({ message: 'Unable to retrieve roles' }, { status: 500 });
+        }
+
+        return jsonResponse(data ?? []);
+    } catch (error) {
+        console.error('roles: unexpected error', error);
+        return jsonResponse({ message: 'Unexpected server error' }, { status: 500 });
+    }
+}


### PR DESCRIPTION
## Summary
- add a Netlify function that authenticates POS PINs against the Supabase `roles` table and returns the matching role or null
- add a Netlify function that lists roles (or filters by PIN) via Supabase with consistent JSON/error handling
- ignore the local `.netlify` folder that the Netlify CLI generates during development

## Testing
- npm run build
- npx --yes netlify functions:serve --port 8888 (requests fail without valid Supabase service credentials)
- curl http://localhost:8888/.netlify/functions/roles (returns 500: fetch failed)
- curl http://localhost:8888/.netlify/functions/auth-login (returns 500: fetch failed)


------
https://chatgpt.com/codex/tasks/task_b_68cea9381a44832a8c7e3f16c50e9b67