### PR TITLE
Fix auth login endpoint slug

### DIFF
--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -90,7 +90,7 @@ export const api = {
     // --- Auth & Roles ---
     getRoles: (): Promise<Role[]> => apiFetch('/roles'),
     saveRoles: (newRoles: Role[]): Promise<void> => apiFetch('/roles', { method: 'POST', body: JSON.stringify(newRoles) }),
-    loginWithPin: (pin: string): Promise<Role | null> => apiFetch('/auth/login', { method: 'POST', body: JSON.stringify({ pin }) }),
+    loginWithPin: (pin: string): Promise<Role | null> => apiFetch('/auth-login', { method: 'POST', body: JSON.stringify({ pin }) }),
 
     // --- POS - Commande ---
     getCommandeByTableId: (tableId: number): Promise<Commande | null> => apiFetch(`/commandes?tableId=${tableId}`),


### PR DESCRIPTION
## Summary
- point the PIN login API call at the Netlify-generated `auth-login` function slug

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ceb1e3530c832aa37d827823413236