### PR TITLE
Implement Netlify function handlers for POS API

### DIFF
--- a/netlify/functions/_shared/cloudinary.ts
+++ b/netlify/functions/_shared/cloudinary.ts
@@ -1,0 +1,88 @@
+import crypto from 'node:crypto';
+
+const CLOUDINARY_CLOUD_NAME = process.env.CLOUDINARY_CLOUD_NAME ?? process.env.VITE_CLOUDINARY_CLOUD_NAME;
+const CLOUDINARY_API_KEY = process.env.CLOUDINARY_API_KEY ?? process.env.VITE_CLOUDINARY_API_KEY;
+const CLOUDINARY_API_SECRET = process.env.CLOUDINARY_API_SECRET ?? process.env.VITE_CLOUDINARY_API_SECRET;
+const CLOUDINARY_UPLOAD_PRESET = process.env.CLOUDINARY_UPLOAD_PRESET ?? process.env.VITE_CLOUDINARY_UPLOAD_PRESET;
+
+export const isCloudinaryConfigured = (): boolean =>
+    Boolean(CLOUDINARY_CLOUD_NAME && CLOUDINARY_API_KEY && CLOUDINARY_API_SECRET);
+
+const buildSignature = (params: Record<string, string>): string => {
+    const sorted = Object.keys(params)
+        .sort()
+        .map(key => `${key}=${params[key]}`)
+        .join('&');
+    return crypto.createHash('sha1').update(`${sorted}${CLOUDINARY_API_SECRET}`).digest('hex');
+};
+
+export const generateUploadSignature = () => {
+    if (!isCloudinaryConfigured()) {
+        throw new Error('Cloudinary credentials are not configured.');
+    }
+    const timestamp = Math.floor(Date.now() / 1000);
+    const params: Record<string, string> = { timestamp: `${timestamp}` };
+    if (CLOUDINARY_UPLOAD_PRESET) {
+        params.upload_preset = CLOUDINARY_UPLOAD_PRESET;
+    }
+    const signature = buildSignature(params);
+    return {
+        signature,
+        timestamp,
+        apiKey: CLOUDINARY_API_KEY,
+        cloudName: CLOUDINARY_CLOUD_NAME,
+        uploadPreset: CLOUDINARY_UPLOAD_PRESET,
+    };
+};
+
+export interface UploadImageOptions {
+    folder?: string;
+}
+
+export interface CloudinaryUploadResult {
+    public_id: string;
+    secure_url: string;
+}
+
+export const uploadImageToCloudinary = async (file: File, options: UploadImageOptions = {}): Promise<CloudinaryUploadResult> => {
+    if (!isCloudinaryConfigured()) {
+        throw new Error('Cloudinary credentials are not configured.');
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const timestamp = Math.floor(Date.now() / 1000);
+    const params: Record<string, string> = { timestamp: `${timestamp}` };
+    if (options.folder) {
+        params.folder = options.folder;
+    }
+    if (CLOUDINARY_UPLOAD_PRESET) {
+        params.upload_preset = CLOUDINARY_UPLOAD_PRESET;
+    }
+
+    const signature = buildSignature(params);
+
+    const formData = new FormData();
+    formData.append('file', new Blob([buffer]), file.name || 'upload.jpg');
+    formData.append('api_key', CLOUDINARY_API_KEY!);
+    formData.append('timestamp', `${timestamp}`);
+    formData.append('signature', signature);
+    if (options.folder) {
+        formData.append('folder', options.folder);
+    }
+    if (CLOUDINARY_UPLOAD_PRESET) {
+        formData.append('upload_preset', CLOUDINARY_UPLOAD_PRESET);
+    }
+
+    const response = await fetch(`https://api.cloudinary.com/v1_1/${CLOUDINARY_CLOUD_NAME}/image/upload`, {
+        method: 'POST',
+        body: formData,
+    });
+
+    if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(`Cloudinary upload failed: ${errorBody}`);
+    }
+
+    const payload = (await response.json()) as CloudinaryUploadResult;
+    return payload;
+};

--- a/netlify/functions/_shared/commandes.ts
+++ b/netlify/functions/_shared/commandes.ts
@@ -1,0 +1,45 @@
+import type { Commande, CommandeItem } from '../../../types';
+
+export const COMMANDE_SELECT =
+    'id, table_id, items, statut, date_creation, couverts, estado_cocina, date_envoi_cuisine, date_listo_cuisine, date_servido, date_dernier_envoi_cuisine, payment_status, customer_name, customer_address, payment_method, receipt_image_base64';
+
+export interface CommandeRow {
+    id: string;
+    table_id: number | null;
+    items: CommandeItem[] | null;
+    statut: Commande['statut'];
+    date_creation: string;
+    couverts: number | null;
+    estado_cocina: Commande['estado_cocina'];
+    date_envoi_cuisine: string | null;
+    date_listo_cuisine: string | null;
+    date_servido: string | null;
+    date_dernier_envoi_cuisine: string | null;
+    payment_status: Commande['payment_status'];
+    customer_name: string | null;
+    customer_address: string | null;
+    payment_method: string | null;
+    receipt_image_base64: string | null;
+}
+
+export const mapCommandeRow = (row: CommandeRow): Commande => ({
+    id: row.id,
+    table_id: row.table_id ?? 0,
+    items: row.items ?? [],
+    statut: row.statut,
+    date_creation: row.date_creation,
+    couverts: row.couverts ?? 0,
+    estado_cocina: row.estado_cocina ?? null,
+    date_envoi_cuisine: row.date_envoi_cuisine ?? undefined,
+    date_listo_cuisine: row.date_listo_cuisine ?? undefined,
+    date_servido: row.date_servido ?? undefined,
+    date_dernier_envoi_cuisine: row.date_dernier_envoi_cuisine ?? undefined,
+    payment_status: row.payment_status ?? 'impaye',
+    customer_name: row.customer_name ?? undefined,
+    customer_address: row.customer_address ?? undefined,
+    payment_method: row.payment_method ?? undefined,
+    receipt_image_base64: row.receipt_image_base64 ?? undefined,
+});
+
+export const calculateCommandeTotal = (commande: Commande): number =>
+    commande.items.reduce((total, item) => total + item.produit.prix_vente * item.quantite, 0);

--- a/netlify/functions/_shared/ingredients.ts
+++ b/netlify/functions/_shared/ingredients.ts
@@ -1,0 +1,28 @@
+import type { Ingredient, IngredientLot } from '../../../types';
+
+export const INGREDIENT_SELECT =
+    'id, nom, unite, stock_minimum, stock_actuel, prix_unitaire, date_below_minimum, last_known_price, lots:ingredient_lots (quantite_initiale, quantite_restante, prix_unitaire_achat, date_achat)';
+
+export interface IngredientRow {
+    id: number;
+    nom: string;
+    unite: string;
+    stock_minimum: number;
+    stock_actuel: number | null;
+    prix_unitaire: number | null;
+    date_below_minimum: string | null;
+    last_known_price: number | null;
+    lots: IngredientLot[] | null;
+}
+
+export const mapIngredientRow = (row: IngredientRow): Ingredient => ({
+    id: row.id,
+    nom: row.nom,
+    unite: row.unite as Ingredient['unite'],
+    stock_minimum: row.stock_minimum,
+    stock_actuel: row.stock_actuel ?? 0,
+    prix_unitaire: row.prix_unitaire ?? 0,
+    date_below_minimum: row.date_below_minimum ?? undefined,
+    last_known_price: row.last_known_price ?? undefined,
+    lots: row.lots ?? [],
+});

--- a/netlify/functions/_shared/products.ts
+++ b/netlify/functions/_shared/products.ts
@@ -1,0 +1,21 @@
+import type { Produit } from '../../../types';
+
+export const PRODUCT_SELECT = 'id, nom_produit, prix_vente, categoria_id, estado, image_base64';
+
+export interface ProductRow {
+    id: number;
+    nom_produit: string;
+    prix_vente: number;
+    categoria_id: number;
+    estado: Produit['estado'];
+    image_base64: string | null;
+}
+
+export const mapProductRow = (row: ProductRow): Produit => ({
+    id: row.id,
+    nom_produit: row.nom_produit,
+    prix_vente: row.prix_vente,
+    categoria_id: row.categoria_id,
+    estado: row.estado,
+    image_base64: row.image_base64 ?? undefined,
+});

--- a/netlify/functions/_shared/response.ts
+++ b/netlify/functions/_shared/response.ts
@@ -1,0 +1,34 @@
+export const jsonResponse = (body: unknown, init: ResponseInit = {}): Response =>
+    new Response(JSON.stringify(body), {
+        headers: {
+            'Content-Type': 'application/json',
+            ...(init.headers ?? {}),
+        },
+        ...init,
+    });
+
+export const methodNotAllowed = (allowed: string[]): Response =>
+    new Response(JSON.stringify({ message: 'Method Not Allowed' }), {
+        status: 405,
+        headers: {
+            'Content-Type': 'application/json',
+            Allow: allowed.join(', '),
+        },
+    });
+
+export const badRequest = (message: string): Response =>
+    jsonResponse({ message }, { status: 400 });
+
+export const notFound = (message = 'Not Found'): Response =>
+    jsonResponse({ message }, { status: 404 });
+
+export const internalError = (message = 'Unexpected server error'): Response =>
+    jsonResponse({ message }, { status: 500 });
+
+export const parseJson = async <T>(request: Request): Promise<T> => {
+    try {
+        return (await request.json()) as T;
+    } catch (error) {
+        throw new Error('Invalid JSON body');
+    }
+};

--- a/netlify/functions/_shared/supabase.ts
+++ b/netlify/functions/_shared/supabase.ts
@@ -1,0 +1,25 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ??
+    process.env.SUPABASE_SERVICE_KEY ??
+    process.env.SUPABASE_SERVICE_API_KEY;
+
+let client: SupabaseClient | null = null;
+
+export const getSupabaseClient = (): SupabaseClient => {
+    if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+        throw new Error('Supabase service credentials are not configured.');
+    }
+
+    if (!client) {
+        client = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+            auth: {
+                persistSession: false,
+            },
+        });
+    }
+
+    return client;
+};

--- a/netlify/functions/categories/id.ts
+++ b/netlify/functions/categories/id.ts
@@ -1,0 +1,38 @@
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/categories/:id' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'DELETE') {
+        return methodNotAllowed(['DELETE']);
+    }
+
+    const url = new URL(request.url);
+    const idParam = url.pathname.split('/').pop();
+    const id = Number(idParam);
+
+    if (!id || Number.isNaN(id)) {
+        return badRequest('Invalid category id');
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('categories/:id: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { error } = await supabase.from('categories').delete().eq('id', id);
+        if (error) {
+            console.error('categories/:id: Supabase delete error', error);
+            return internalError('Unable to delete category');
+        }
+        return new Response(null, { status: 204 });
+    } catch (error) {
+        console.error('categories/:id: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/categories/index.ts
+++ b/netlify/functions/categories/index.ts
@@ -1,0 +1,56 @@
+import type { Categoria } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed, parseJson } from '../_shared/response';
+
+export const config = { path: '/categories' };
+
+interface CategoryPayload {
+    nom: string;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return methodNotAllowed(['POST']);
+    }
+
+    let payload: CategoryPayload;
+    try {
+        payload = await parseJson<CategoryPayload>(request);
+    } catch (error) {
+        return badRequest('Invalid JSON body');
+    }
+
+    if (!payload.nom || payload.nom.trim().length === 0) {
+        return badRequest('Category name is required');
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('categories: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from<Categoria>('categories')
+            .insert({ nom: payload.nom })
+            .select('*')
+            .maybeSingle();
+
+        if (error) {
+            console.error('categories: Supabase insert error', error);
+            return internalError('Unable to create category');
+        }
+
+        if (!data) {
+            return internalError('Category creation failed');
+        }
+
+        return jsonResponse(data, { status: 201 });
+    } catch (error) {
+        console.error('categories: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/cloudinary/signature.ts
+++ b/netlify/functions/cloudinary/signature.ts
@@ -1,0 +1,22 @@
+import { generateUploadSignature, isCloudinaryConfigured } from '../_shared/cloudinary';
+import { jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/cloudinary/signature' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return methodNotAllowed(['POST']);
+    }
+
+    if (!isCloudinaryConfigured()) {
+        return jsonResponse({ message: 'Cloudinary is not configured' }, { status: 500 });
+    }
+
+    try {
+        const payload = generateUploadSignature();
+        return jsonResponse(payload);
+    } catch (error) {
+        console.error('cloudinary/signature: failed to generate signature', error);
+        return jsonResponse({ message: 'Unable to generate signature' }, { status: 500 });
+    }
+}

--- a/netlify/functions/commandes/active.ts
+++ b/netlify/functions/commandes/active.ts
@@ -1,0 +1,38 @@
+import type { Commande } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+import { COMMANDE_SELECT, type CommandeRow, mapCommandeRow } from '../_shared/commandes';
+
+export const config = { path: '/commandes/active' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'GET') {
+        return methodNotAllowed(['GET']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('commandes/active: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from<CommandeRow>('commandes')
+            .select(COMMANDE_SELECT)
+            .in('statut', ['en_cours', 'pendiente_validacion']);
+
+        if (error) {
+            console.error('commandes/active: Supabase query error', error);
+            return internalError('Unable to retrieve commandes');
+        }
+
+        const commandes: Commande[] = (data ?? []).map(mapCommandeRow);
+        return jsonResponse(commandes);
+    } catch (error) {
+        console.error('commandes/active: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/commandes/cancel-empty.ts
+++ b/netlify/functions/commandes/cancel-empty.ts
@@ -1,0 +1,54 @@
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/commandes/:id/cancel-empty' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'DELETE') {
+        return methodNotAllowed(['DELETE']);
+    }
+
+    const url = new URL(request.url);
+    const segments = url.pathname.split('/');
+    const commandeId = segments[segments.length - 2];
+
+    if (!commandeId) {
+        return jsonResponse({ message: 'Invalid commande id' }, { status: 400 });
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('commandes/:id/cancel-empty: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from('commandes')
+            .select('table_id')
+            .eq('id', commandeId)
+            .maybeSingle();
+
+        if (error) {
+            console.error('commandes/:id/cancel-empty: Supabase lookup error', error);
+            return internalError('Unable to cancel commande');
+        }
+
+        const { error: deleteError } = await supabase.from('commandes').delete().eq('id', commandeId);
+        if (deleteError) {
+            console.error('commandes/:id/cancel-empty: Supabase delete error', deleteError);
+            return internalError('Unable to cancel commande');
+        }
+
+        if (data?.table_id) {
+            await supabase.from('tables').update({ statut: 'libre', commande_id: null, couverts: null }).eq('id', data.table_id);
+        }
+
+        return new Response(null, { status: 204 });
+    } catch (error) {
+        console.error('commandes/:id/cancel-empty: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/commandes/cancel-unpaid.ts
+++ b/netlify/functions/commandes/cancel-unpaid.ts
@@ -1,0 +1,51 @@
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/commandes/:id/cancel-unpaid' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return methodNotAllowed(['POST']);
+    }
+
+    const url = new URL(request.url);
+    const segments = url.pathname.split('/');
+    const commandeId = segments[segments.length - 2];
+
+    if (!commandeId) {
+        return jsonResponse({ message: 'Invalid commande id' }, { status: 400 });
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('commandes/:id/cancel-unpaid: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    const now = new Date().toISOString();
+
+    try {
+        const { data, error } = await supabase
+            .from('commandes')
+            .update({ statut: 'finalisee', payment_status: 'impaye', date_dernier_envoi_cuisine: now })
+            .eq('id', commandeId)
+            .select('table_id')
+            .maybeSingle();
+
+        if (error) {
+            console.error('commandes/:id/cancel-unpaid: Supabase update error', error);
+            return internalError('Unable to cancel commande');
+        }
+
+        if (data?.table_id) {
+            await supabase.from('tables').update({ statut: 'libre', commande_id: null, couverts: null }).eq('id', data.table_id);
+        }
+
+        return new Response(null, { status: 204 });
+    } catch (error) {
+        console.error('commandes/:id/cancel-unpaid: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/commandes/finalize.ts
+++ b/netlify/functions/commandes/finalize.ts
@@ -1,0 +1,59 @@
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/commandes/:id/finalize' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return methodNotAllowed(['POST']);
+    }
+
+    const url = new URL(request.url);
+    const segments = url.pathname.split('/');
+    const commandeId = segments[segments.length - 2];
+
+    if (!commandeId) {
+        return jsonResponse({ message: 'Invalid commande id' }, { status: 400 });
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('commandes/:id/finalize: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    const now = new Date().toISOString();
+
+    try {
+        const { data, error } = await supabase
+            .from('commandes')
+            .update({
+                statut: 'finalisee',
+                estado_cocina: 'servido',
+                date_servido: now,
+                date_dernier_envoi_cuisine: now,
+            })
+            .eq('id', commandeId)
+            .select('table_id')
+            .maybeSingle();
+
+        if (error) {
+            console.error('commandes/:id/finalize: Supabase update error', error);
+            return internalError('Unable to finalize commande');
+        }
+
+        if (data?.table_id) {
+            await supabase
+                .from('tables')
+                .update({ statut: 'libre', commande_id: null, couverts: null })
+                .eq('id', data.table_id);
+        }
+
+        return new Response(null, { status: 204 });
+    } catch (error) {
+        console.error('commandes/:id/finalize: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/commandes/id.ts
+++ b/netlify/functions/commandes/id.ts
@@ -1,0 +1,82 @@
+import type { Commande, CommandeItem } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed, parseJson } from '../_shared/response';
+import { COMMANDE_SELECT, type CommandeRow, mapCommandeRow } from '../_shared/commandes';
+
+export const config = { path: '/commandes/:id' };
+
+interface UpdateCommandePayload {
+    items?: CommandeItem[];
+    couverts?: number;
+}
+
+const loadCommande = async (id: string): Promise<Commande> => {
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase
+        .from<CommandeRow>('commandes')
+        .select(COMMANDE_SELECT)
+        .eq('id', id)
+        .maybeSingle();
+    if (error) {
+        throw new Error(error.message);
+    }
+    if (!data) {
+        throw new Error('Commande not found');
+    }
+    return mapCommandeRow(data);
+};
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'PATCH') {
+        return methodNotAllowed(['PATCH']);
+    }
+
+    const url = new URL(request.url);
+    const idParam = url.pathname.split('/').pop();
+    const commandeId = idParam ?? '';
+
+    if (!commandeId) {
+        return badRequest('Invalid commande id');
+    }
+
+    let payload: UpdateCommandePayload;
+    try {
+        payload = await parseJson<UpdateCommandePayload>(request);
+    } catch (error) {
+        return badRequest('Invalid JSON body');
+    }
+
+    const updateData: Record<string, unknown> = {};
+    if (payload.items) {
+        updateData.items = payload.items;
+    }
+    if (typeof payload.couverts === 'number') {
+        updateData.couverts = payload.couverts;
+    }
+
+    if (Object.keys(updateData).length === 0) {
+        return badRequest('No updates provided');
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('commandes/:id: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { error } = await supabase.from('commandes').update(updateData).eq('id', commandeId);
+        if (error) {
+            console.error('commandes/:id: Supabase update error', error);
+            return internalError('Unable to update commande');
+        }
+
+        const commande = await loadCommande(commandeId);
+        return jsonResponse(commande);
+    } catch (error) {
+        console.error('commandes/:id: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/commandes/index.ts
+++ b/netlify/functions/commandes/index.ts
@@ -1,0 +1,116 @@
+import type { Commande } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed, parseJson } from '../_shared/response';
+import { COMMANDE_SELECT, type CommandeRow, mapCommandeRow } from '../_shared/commandes';
+
+export const config = { path: '/commandes' };
+
+interface CreateCommandePayload {
+    tableId: number;
+    couverts: number;
+}
+
+const loadCommandeById = async (id: string): Promise<Commande | null> => {
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase
+        .from<CommandeRow>('commandes')
+        .select(COMMANDE_SELECT)
+        .eq('id', id)
+        .maybeSingle();
+    if (error) {
+        throw new Error(error.message);
+    }
+    return data ? mapCommandeRow(data) : null;
+};
+
+export default async function handler(request: Request): Promise<Response> {
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('commandes: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    if (request.method === 'GET') {
+        const url = new URL(request.url);
+        const tableIdParam = url.searchParams.get('tableId');
+        const commandeId = url.searchParams.get('commandeId');
+
+        try {
+            if (commandeId) {
+                const commande = await loadCommandeById(commandeId);
+                return jsonResponse(commande);
+            }
+
+            if (tableIdParam) {
+                const tableId = Number(tableIdParam);
+                if (!tableId || Number.isNaN(tableId)) {
+                    return badRequest('Invalid table id');
+                }
+                const { data, error } = await supabase
+                    .from<CommandeRow>('commandes')
+                    .select(COMMANDE_SELECT)
+                    .eq('table_id', tableId)
+                    .in('statut', ['en_cours', 'pendiente_validacion'])
+                    .maybeSingle();
+                if (error) {
+                    console.error('commandes: failed to fetch by table id', error);
+                    return internalError('Unable to retrieve commande');
+                }
+                return jsonResponse(data ? mapCommandeRow(data) : null);
+            }
+
+            return badRequest('Missing lookup parameters');
+        } catch (error) {
+            console.error('commandes: unexpected fetch error', error);
+            return internalError();
+        }
+    }
+
+    if (request.method === 'POST') {
+        let payload: CreateCommandePayload;
+        try {
+            payload = await parseJson<CreateCommandePayload>(request);
+        } catch (error) {
+            return badRequest('Invalid JSON body');
+        }
+
+        if (!payload.tableId || typeof payload.couverts !== 'number') {
+            return badRequest('Missing required fields');
+        }
+
+        const now = new Date().toISOString();
+
+        try {
+            const { data, error } = await supabase
+                .from('commandes')
+                .insert({
+                    table_id: payload.tableId,
+                    couverts: payload.couverts,
+                    statut: 'en_cours',
+                    date_creation: now,
+                    items: [],
+                    estado_cocina: null,
+                    payment_status: 'impaye',
+                })
+                .select('id')
+                .maybeSingle();
+
+            if (error || !data) {
+                console.error('commandes: Supabase insert error', error);
+                return internalError('Unable to create commande');
+            }
+
+            await supabase.from('tables').update({ statut: 'occupee', commande_id: data.id }).eq('id', payload.tableId);
+
+            const commande = await loadCommandeById(data.id as string);
+            return jsonResponse(commande, { status: 201 });
+        } catch (error) {
+            console.error('commandes: unexpected create error', error);
+            return internalError();
+        }
+    }
+
+    return methodNotAllowed(['GET', 'POST']);
+}

--- a/netlify/functions/commandes/pay.ts
+++ b/netlify/functions/commandes/pay.ts
@@ -1,0 +1,41 @@
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/commandes/:id/pay' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return methodNotAllowed(['POST']);
+    }
+
+    const url = new URL(request.url);
+    const segments = url.pathname.split('/');
+    const commandeId = segments[segments.length - 2];
+
+    if (!commandeId) {
+        return jsonResponse({ message: 'Invalid commande id' }, { status: 400 });
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('commandes/:id/pay: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { error } = await supabase
+            .from('commandes')
+            .update({ payment_status: 'paye' })
+            .eq('id', commandeId);
+        if (error) {
+            console.error('commandes/:id/pay: Supabase update error', error);
+            return internalError('Unable to mark commande as paid');
+        }
+        return new Response(null, { status: 204 });
+    } catch (error) {
+        console.error('commandes/:id/pay: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/data/categories.ts
+++ b/netlify/functions/data/categories.ts
@@ -1,0 +1,36 @@
+import type { Categoria } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/data/categories' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'GET') {
+        return methodNotAllowed(['GET']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('data/categories: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from<Categoria>('categories')
+            .select('*')
+            .order('nom', { ascending: true });
+
+        if (error) {
+            console.error('data/categories: Supabase query error', error);
+            return internalError('Unable to retrieve categories');
+        }
+
+        return jsonResponse(data ?? []);
+    } catch (error) {
+        console.error('data/categories: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/data/ingredients.ts
+++ b/netlify/functions/data/ingredients.ts
@@ -1,0 +1,39 @@
+import type { Ingredient } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+import { INGREDIENT_SELECT, type IngredientRow, mapIngredientRow } from '../_shared/ingredients';
+
+export const config = { path: '/data/ingredients' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'GET') {
+        return methodNotAllowed(['GET']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('data/ingredients: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from<IngredientRow>('ingredients')
+            .select(INGREDIENT_SELECT)
+            .order('nom', { ascending: true });
+
+        if (error) {
+            console.error('data/ingredients: Supabase query error', error);
+            return internalError('Unable to retrieve ingredients');
+        }
+
+        const ingredients: Ingredient[] = (data ?? []).map(mapIngredientRow);
+
+        return jsonResponse(ingredients);
+    } catch (error) {
+        console.error('data/ingredients: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/data/products.ts
+++ b/netlify/functions/data/products.ts
@@ -1,0 +1,54 @@
+import type { Produit } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/data/products' };
+
+interface ProduitRow {
+    id: number;
+    nom_produit: string;
+    prix_vente: number;
+    categoria_id: number;
+    estado: Produit['estado'];
+    image_base64: string | null;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'GET') {
+        return methodNotAllowed(['GET']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('data/products: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from<ProduitRow>('produits')
+            .select('id, nom_produit, prix_vente, categoria_id, estado, image_base64')
+            .order('nom_produit', { ascending: true });
+
+        if (error) {
+            console.error('data/products: Supabase query error', error);
+            return internalError('Unable to retrieve products');
+        }
+
+        const produits: Produit[] = (data ?? []).map(row => ({
+            id: row.id,
+            nom_produit: row.nom_produit,
+            prix_vente: row.prix_vente,
+            categoria_id: row.categoria_id,
+            estado: row.estado,
+            image_base64: row.image_base64 ?? undefined,
+        }));
+
+        return jsonResponse(produits);
+    } catch (error) {
+        console.error('data/products: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/data/purchases.ts
+++ b/netlify/functions/data/purchases.ts
@@ -1,0 +1,36 @@
+import type { Achat } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/data/purchases' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'GET') {
+        return methodNotAllowed(['GET']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('data/purchases: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from<Achat>('achats')
+            .select('*')
+            .order('date_achat', { ascending: false });
+
+        if (error) {
+            console.error('data/purchases: Supabase query error', error);
+            return internalError('Unable to retrieve purchases');
+        }
+
+        return jsonResponse(data ?? []);
+    } catch (error) {
+        console.error('data/purchases: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/data/recipes.ts
+++ b/netlify/functions/data/recipes.ts
@@ -1,0 +1,58 @@
+import type { Recette, RecetteItem } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/data/recipes' };
+
+interface RecetteItemRow {
+    produit_id: number;
+    ingredient_id: number;
+    qte_utilisee: number;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'GET') {
+        return methodNotAllowed(['GET']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('data/recipes: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from<RecetteItemRow>('recette_items')
+            .select('produit_id, ingredient_id, qte_utilisee')
+            .order('produit_id', { ascending: true });
+
+        if (error) {
+            console.error('data/recipes: Supabase query error', error);
+            return internalError('Unable to retrieve recipes');
+        }
+
+        const recettesMap = new Map<number, RecetteItem[]>();
+        for (const row of data ?? []) {
+            if (!recettesMap.has(row.produit_id)) {
+                recettesMap.set(row.produit_id, []);
+            }
+            recettesMap.get(row.produit_id)!.push({
+                ingredient_id: row.ingredient_id,
+                qte_utilisee: row.qte_utilisee,
+            });
+        }
+
+        const recettes: Recette[] = Array.from(recettesMap.entries()).map(([produitId, items]) => ({
+            produit_id: produitId,
+            items,
+        }));
+
+        return jsonResponse(recettes);
+    } catch (error) {
+        console.error('data/recipes: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/data/sales.ts
+++ b/netlify/functions/data/sales.ts
@@ -1,0 +1,36 @@
+import type { Vente } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/data/sales' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'GET') {
+        return methodNotAllowed(['GET']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('data/sales: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from<Vente>('ventes')
+            .select('*')
+            .order('date_vente', { ascending: false });
+
+        if (error) {
+            console.error('data/sales: Supabase query error', error);
+            return internalError('Unable to retrieve sales');
+        }
+
+        return jsonResponse(data ?? []);
+    } catch (error) {
+        console.error('data/sales: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/data/site-assets.ts
+++ b/netlify/functions/data/site-assets.ts
@@ -1,0 +1,43 @@
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/data/site-assets' };
+
+interface SiteAssetRow {
+    key: string;
+    value: string;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'GET') {
+        return methodNotAllowed(['GET']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('data/site-assets: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const tableName = process.env.SUPABASE_SITE_ASSETS_TABLE ?? process.env.VITE_SUPABASE_SITE_ASSETS_TABLE ?? 'site_assets';
+        const { data, error } = await supabase.from<SiteAssetRow>(tableName).select('key, value');
+
+        if (error) {
+            console.error('data/site-assets: Supabase query error', error);
+            return internalError('Unable to retrieve site assets');
+        }
+
+        const assets = (data ?? []).reduce<Record<string, string>>((acc, row) => {
+            acc[row.key] = row.value;
+            return acc;
+        }, {});
+
+        return jsonResponse(assets);
+    } catch (error) {
+        console.error('data/site-assets: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/data/tables.ts
+++ b/netlify/functions/data/tables.ts
@@ -1,0 +1,68 @@
+import type { Table, TableStatus } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/data/tables' };
+
+interface TableRow {
+    id: number;
+    nom: string;
+    capacite: number;
+    statut: string;
+    commande_id: string | null;
+    couverts: number | null;
+    total_commande: number | null;
+    is_ready: boolean | null;
+    ready_timestamp: string | null;
+    creation_timestamp: string | null;
+    sent_to_kitchen_timestamp: string | null;
+    kitchen_status: string | null;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'GET') {
+        return methodNotAllowed(['GET']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('data/tables: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from<TableRow>('tables')
+            .select(
+                'id, nom, capacite, statut, commande_id, couverts, total_commande, is_ready, ready_timestamp, creation_timestamp, sent_to_kitchen_timestamp, kitchen_status'
+            )
+            .order('id', { ascending: true });
+
+        if (error) {
+            console.error('data/tables: Supabase query error', error);
+            return internalError('Unable to retrieve tables');
+        }
+
+        const tables: Table[] = (data ?? []).map(row => ({
+            id: row.id,
+            nom: row.nom,
+            capacite: row.capacite,
+            statut: (row.statut as TableStatus) ?? 'libre',
+            commandeId: row.commande_id ?? undefined,
+            couverts: row.couverts ?? undefined,
+            totalCommande: row.total_commande ?? undefined,
+            isReady: row.is_ready ?? undefined,
+            readyTimestamp: row.ready_timestamp ?? undefined,
+            creationTimestamp: row.creation_timestamp ?? undefined,
+            sentToKitchenTimestamp: row.sent_to_kitchen_timestamp ?? undefined,
+            kitchenStatus: row.kitchen_status as Table['kitchenStatus'],
+        }));
+
+        return jsonResponse(tables);
+    } catch (error) {
+        console.error('data/tables: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/ingredients/id.ts
+++ b/netlify/functions/ingredients/id.ts
@@ -1,0 +1,98 @@
+import type { IngredientPayload, Ingredient } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed, parseJson } from '../_shared/response';
+import { INGREDIENT_SELECT, type IngredientRow, mapIngredientRow } from '../_shared/ingredients';
+
+export const config = { path: '/ingredients/:id' };
+
+const loadIngredient = async (id: number): Promise<Ingredient> => {
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase
+        .from<IngredientRow>('ingredients')
+        .select(INGREDIENT_SELECT)
+        .eq('id', id)
+        .maybeSingle();
+    if (error) {
+        throw new Error(error.message);
+    }
+    if (!data) {
+        throw new Error('Ingredient not found');
+    }
+    return mapIngredientRow(data);
+};
+
+export default async function handler(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const idParam = url.pathname.split('/').pop();
+    const id = Number(idParam);
+
+    if (!id || Number.isNaN(id)) {
+        return badRequest('Invalid ingredient id');
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('ingredients/:id: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    if (request.method === 'PUT') {
+        let payload: IngredientPayload;
+        try {
+            payload = await parseJson<IngredientPayload>(request);
+        } catch (error) {
+            return badRequest('Invalid JSON body');
+        }
+
+        if (!payload.nom || !payload.unite || typeof payload.stock_minimum !== 'number') {
+            return badRequest('Missing required ingredient fields');
+        }
+
+        try {
+            const { error } = await supabase
+                .from('ingredients')
+                .update({
+                    nom: payload.nom,
+                    unite: payload.unite,
+                    stock_minimum: payload.stock_minimum,
+                })
+                .eq('id', id);
+
+            if (error) {
+                console.error('ingredients/:id: Supabase update error', error);
+                return internalError('Unable to update ingredient');
+            }
+
+            let ingredient: Ingredient;
+            try {
+                ingredient = await loadIngredient(id);
+            } catch (fetchError) {
+                console.error('ingredients/:id: failed to reload ingredient', fetchError);
+                return internalError('Ingredient updated but could not be retrieved');
+            }
+
+            return jsonResponse(ingredient);
+        } catch (error) {
+            console.error('ingredients/:id: unexpected update error', error);
+            return internalError();
+        }
+    }
+
+    if (request.method === 'DELETE') {
+        try {
+            const { error } = await supabase.from('ingredients').delete().eq('id', id);
+            if (error) {
+                console.error('ingredients/:id: Supabase delete error', error);
+                return internalError('Unable to delete ingredient');
+            }
+            return new Response(null, { status: 204 });
+        } catch (error) {
+            console.error('ingredients/:id: unexpected delete error', error);
+            return internalError();
+        }
+    }
+
+    return methodNotAllowed(['PUT', 'DELETE']);
+}

--- a/netlify/functions/ingredients/index.ts
+++ b/netlify/functions/ingredients/index.ts
@@ -1,0 +1,84 @@
+import type { Ingredient, IngredientPayload } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed, parseJson } from '../_shared/response';
+import { INGREDIENT_SELECT, type IngredientRow, mapIngredientRow } from '../_shared/ingredients';
+
+export const config = { path: '/ingredients' };
+
+const fetchIngredientById = async (id: number) => {
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase
+        .from<IngredientRow>('ingredients')
+        .select(INGREDIENT_SELECT)
+        .eq('id', id)
+        .maybeSingle();
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    if (!data) {
+        throw new Error('Ingredient not found');
+    }
+
+    return mapIngredientRow(data);
+};
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return methodNotAllowed(['POST']);
+    }
+
+    let payload: IngredientPayload;
+    try {
+        payload = await parseJson<IngredientPayload>(request);
+    } catch (error) {
+        return badRequest('Invalid JSON body');
+    }
+
+    if (!payload.nom || !payload.unite || typeof payload.stock_minimum !== 'number') {
+        return badRequest('Missing required ingredient fields');
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('ingredients: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from('ingredients')
+            .insert({
+                nom: payload.nom,
+                unite: payload.unite,
+                stock_minimum: payload.stock_minimum,
+            })
+            .select('id')
+            .maybeSingle();
+
+        if (error) {
+            console.error('ingredients: Supabase insert error', error);
+            return internalError('Unable to create ingredient');
+        }
+
+        if (!data) {
+            return internalError('Ingredient creation failed');
+        }
+
+        let ingredient: Ingredient;
+        try {
+            ingredient = await fetchIngredientById(data.id as number);
+        } catch (fetchError) {
+            console.error('ingredients: failed to load created ingredient', fetchError);
+            return internalError('Ingredient created but could not be retrieved');
+        }
+
+        return jsonResponse(ingredient, { status: 201 });
+    } catch (error) {
+        console.error('ingredients: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/ingredients/purchase.ts
+++ b/netlify/functions/ingredients/purchase.ts
@@ -1,0 +1,80 @@
+import type { Achat } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed, parseJson } from '../_shared/response';
+
+export const config = { path: '/ingredients/purchase' };
+
+interface PurchasePayload {
+    ingredient_id: number;
+    quantite_achetee: number;
+    prix_total: number;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return methodNotAllowed(['POST']);
+    }
+
+    let payload: PurchasePayload;
+    try {
+        payload = await parseJson<PurchasePayload>(request);
+    } catch (error) {
+        return badRequest('Invalid JSON body');
+    }
+
+    const { ingredient_id, quantite_achetee, prix_total } = payload;
+    if (!ingredient_id || quantite_achetee <= 0 || prix_total <= 0) {
+        return badRequest('Missing or invalid purchase fields');
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('ingredients/purchase: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    const now = new Date().toISOString();
+    const prixUnitaire = prix_total / quantite_achetee;
+
+    try {
+        const { error: lotError } = await supabase.from('ingredient_lots').insert({
+            ingredient_id,
+            quantite_initiale: quantite_achetee,
+            quantite_restante: quantite_achetee,
+            prix_unitaire_achat: prixUnitaire,
+            date_achat: now,
+        });
+
+        if (lotError) {
+            console.error('ingredients/purchase: Supabase lot insert error', lotError);
+            return internalError('Unable to record inventory lot');
+        }
+
+        const { data, error } = await supabase
+            .from<Achat>('achats')
+            .insert({
+                ingredient_id,
+                quantite_achetee,
+                prix_total,
+                date_achat: now,
+            })
+            .select('*')
+            .maybeSingle();
+
+        if (error) {
+            console.error('ingredients/purchase: Supabase achat insert error', error);
+            return internalError('Unable to record purchase');
+        }
+
+        if (!data) {
+            return internalError('Purchase was not recorded');
+        }
+
+        return jsonResponse(data, { status: 201 });
+    } catch (error) {
+        console.error('ingredients/purchase: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/kitchen/acknowledge.ts
+++ b/netlify/functions/kitchen/acknowledge.ts
@@ -1,0 +1,42 @@
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/kitchen/acknowledge/:id' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return methodNotAllowed(['POST']);
+    }
+
+    const url = new URL(request.url);
+    const commandeId = url.pathname.split('/').pop();
+
+    if (!commandeId) {
+        return jsonResponse({ message: 'Invalid commande id' }, { status: 400 });
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('kitchen/acknowledge: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    const now = new Date().toISOString();
+
+    try {
+        const { error } = await supabase
+            .from('commandes')
+            .update({ estado_cocina: 'servido', date_servido: now })
+            .eq('id', commandeId);
+        if (error) {
+            console.error('kitchen/acknowledge: Supabase update error', error);
+            return internalError('Unable to acknowledge commande');
+        }
+        return new Response(null, { status: 204 });
+    } catch (error) {
+        console.error('kitchen/acknowledge: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/kitchen/orders.ts
+++ b/netlify/functions/kitchen/orders.ts
@@ -1,0 +1,39 @@
+import type { Commande } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+import { COMMANDE_SELECT, type CommandeRow, mapCommandeRow } from '../_shared/commandes';
+
+export const config = { path: '/kitchen/orders' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'GET') {
+        return methodNotAllowed(['GET']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('kitchen/orders: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from<CommandeRow>('commandes')
+            .select(COMMANDE_SELECT)
+            .in('statut', ['en_cours', 'pendiente_validacion'])
+            .order('date_creation', { ascending: true });
+
+        if (error) {
+            console.error('kitchen/orders: Supabase query error', error);
+            return internalError('Unable to retrieve kitchen orders');
+        }
+
+        const commandes: Commande[] = (data ?? []).map(mapCommandeRow);
+        return jsonResponse(commandes);
+    } catch (error) {
+        console.error('kitchen/orders: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/kitchen/ready.ts
+++ b/netlify/functions/kitchen/ready.ts
@@ -1,0 +1,42 @@
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/kitchen/ready/:id' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return methodNotAllowed(['POST']);
+    }
+
+    const url = new URL(request.url);
+    const commandeId = url.pathname.split('/').pop();
+
+    if (!commandeId) {
+        return jsonResponse({ message: 'Invalid commande id' }, { status: 400 });
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('kitchen/ready: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    const now = new Date().toISOString();
+
+    try {
+        const { error } = await supabase
+            .from('commandes')
+            .update({ estado_cocina: 'listo', date_listo_cuisine: now })
+            .eq('id', commandeId);
+        if (error) {
+            console.error('kitchen/ready: Supabase update error', error);
+            return internalError('Unable to mark commande as ready');
+        }
+        return new Response(null, { status: 204 });
+    } catch (error) {
+        console.error('kitchen/ready: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/kitchen/send.ts
+++ b/netlify/functions/kitchen/send.ts
@@ -1,0 +1,47 @@
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/kitchen/send/:id' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return methodNotAllowed(['POST']);
+    }
+
+    const url = new URL(request.url);
+    const segments = url.pathname.split('/');
+    const commandeId = segments[segments.length - 1];
+
+    if (!commandeId) {
+        return jsonResponse({ message: 'Invalid commande id' }, { status: 400 });
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('kitchen/send: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    const now = new Date().toISOString();
+
+    try {
+        const { error } = await supabase
+            .from('commandes')
+            .update({
+                estado_cocina: 'recibido',
+                date_envoi_cuisine: now,
+                date_dernier_envoi_cuisine: now,
+            })
+            .eq('id', commandeId);
+        if (error) {
+            console.error('kitchen/send: Supabase update error', error);
+            return internalError('Unable to send commande to kitchen');
+        }
+        return new Response(null, { status: 204 });
+    } catch (error) {
+        console.error('kitchen/send: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/products/id.ts
+++ b/netlify/functions/products/id.ts
@@ -1,0 +1,100 @@
+import type { Produit, ProduitPayload } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed, parseJson } from '../_shared/response';
+import { PRODUCT_SELECT, type ProductRow, mapProductRow } from '../_shared/products';
+
+export const config = { path: '/products/:id' };
+
+const loadProduct = async (id: number): Promise<Produit> => {
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase
+        .from<ProductRow>('produits')
+        .select(PRODUCT_SELECT)
+        .eq('id', id)
+        .maybeSingle();
+    if (error) {
+        throw new Error(error.message);
+    }
+    if (!data) {
+        throw new Error('Product not found');
+    }
+    return mapProductRow(data);
+};
+
+export default async function handler(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const idParam = url.pathname.split('/').pop();
+    const id = Number(idParam);
+
+    if (!id || Number.isNaN(id)) {
+        return badRequest('Invalid product id');
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('products/:id: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    if (request.method === 'PUT') {
+        let payload: ProduitPayload;
+        try {
+            payload = await parseJson<ProduitPayload>(request);
+        } catch (error) {
+            return badRequest('Invalid JSON body');
+        }
+
+        if (!payload.nom_produit || typeof payload.prix_vente !== 'number') {
+            return badRequest('Missing required product fields');
+        }
+
+        try {
+            const { error } = await supabase
+                .from('produits')
+                .update({
+                    nom_produit: payload.nom_produit,
+                    prix_vente: payload.prix_vente,
+                    categoria_id: payload.categoria_id,
+                })
+                .eq('id', id);
+
+            if (error) {
+                console.error('products/:id: Supabase update error', error);
+                return internalError('Unable to update product');
+            }
+
+            try {
+                const produit = await loadProduct(id);
+                return jsonResponse(produit);
+            } catch (fetchError) {
+                console.error('products/:id: failed to reload product', fetchError);
+                return internalError('Product updated but could not be retrieved');
+            }
+        } catch (error) {
+            console.error('products/:id: unexpected update error', error);
+            return internalError();
+        }
+    }
+
+    if (request.method === 'DELETE') {
+        try {
+            const { error: recipeError } = await supabase.from('recette_items').delete().eq('produit_id', id);
+            if (recipeError) {
+                console.error('products/:id: failed to delete recipe items', recipeError);
+            }
+            const { error } = await supabase.from('produits').delete().eq('id', id);
+            if (error) {
+                console.error('products/:id: Supabase delete error', error);
+                return internalError('Unable to delete product');
+            }
+            return new Response(null, { status: 204 });
+        } catch (error) {
+            console.error('products/:id: unexpected delete error', error);
+            return internalError();
+        }
+    }
+
+    return methodNotAllowed(['PUT', 'DELETE']);
+}

--- a/netlify/functions/products/image.ts
+++ b/netlify/functions/products/image.ts
@@ -1,0 +1,101 @@
+import type { Produit } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+import { PRODUCT_SELECT, type ProductRow, mapProductRow } from '../_shared/products';
+import { isCloudinaryConfigured, uploadImageToCloudinary } from '../_shared/cloudinary';
+
+export const config = { path: '/products/:id/image' };
+
+const loadProduct = async (id: number): Promise<Produit> => {
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase
+        .from<ProductRow>('produits')
+        .select(PRODUCT_SELECT)
+        .eq('id', id)
+        .maybeSingle();
+    if (error) {
+        throw new Error(error.message);
+    }
+    if (!data) {
+        throw new Error('Product not found');
+    }
+    return mapProductRow(data);
+};
+
+export default async function handler(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const idParam = url.pathname.split('/').slice(-2)[0];
+    const produitId = Number(idParam);
+
+    if (!produitId || Number.isNaN(produitId)) {
+        return badRequest('Invalid product id');
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('products/:id/image: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    if (request.method === 'PUT') {
+        const formData = await request.formData();
+        const file = formData.get('image');
+
+        if (!(file instanceof File)) {
+            return badRequest('Missing product image file');
+        }
+
+        try {
+            if (isCloudinaryConfigured()) {
+                const result = await uploadImageToCloudinary(file, { folder: 'products' });
+                const { error } = await supabase
+                    .from('produits')
+                    .update({ image_base64: result.secure_url })
+                    .eq('id', produitId);
+                if (error) {
+                    console.error('products/:id/image: Supabase update error', error);
+                    return internalError('Unable to update product image');
+                }
+            } else {
+                const buffer = Buffer.from(await file.arrayBuffer());
+                const dataUrl = `data:${file.type};base64,${buffer.toString('base64')}`;
+                const { error } = await supabase
+                    .from('produits')
+                    .update({ image_base64: dataUrl })
+                    .eq('id', produitId);
+                if (error) {
+                    console.error('products/:id/image: Supabase update error (base64)', error);
+                    return internalError('Unable to update product image');
+                }
+            }
+
+            const produit = await loadProduct(produitId);
+            return jsonResponse(produit);
+        } catch (error) {
+            console.error('products/:id/image: unexpected error', error);
+            return internalError();
+        }
+    }
+
+    if (request.method === 'DELETE') {
+        try {
+            const { error } = await supabase
+                .from('produits')
+                .update({ image_base64: null })
+                .eq('id', produitId);
+            if (error) {
+                console.error('products/:id/image: Supabase delete error', error);
+                return internalError('Unable to remove product image');
+            }
+            const produit = await loadProduct(produitId);
+            return jsonResponse(produit);
+        } catch (error) {
+            console.error('products/:id/image: unexpected delete error', error);
+            return internalError();
+        }
+    }
+
+    return methodNotAllowed(['PUT', 'DELETE']);
+}

--- a/netlify/functions/products/index.ts
+++ b/netlify/functions/products/index.ts
@@ -1,0 +1,153 @@
+import type { Produit, ProduitPayload, RecetteItem } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed, parseJson } from '../_shared/response';
+import { PRODUCT_SELECT, type ProductRow, mapProductRow } from '../_shared/products';
+import { isCloudinaryConfigured, uploadImageToCloudinary } from '../_shared/cloudinary';
+
+export const config = { path: '/products' };
+
+interface ProductCreatePayload {
+    product: ProduitPayload;
+    recipeItems: RecetteItem[];
+}
+
+const loadProduct = async (id: number): Promise<Produit> => {
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase
+        .from<ProductRow>('produits')
+        .select(PRODUCT_SELECT)
+        .eq('id', id)
+        .maybeSingle();
+    if (error) {
+        throw new Error(error.message);
+    }
+    if (!data) {
+        throw new Error('Product not found');
+    }
+    return mapProductRow(data);
+};
+
+const parsePayloadFromRequest = async (request: Request): Promise<{ payload: ProductCreatePayload; file: File | null }> => {
+    const contentType = request.headers.get('content-type') ?? '';
+    if (contentType.includes('multipart/form-data')) {
+        const formData = await request.formData();
+        const productRaw = formData.get('product');
+        const recipeItemsRaw = formData.get('recipeItems');
+        const file = formData.get('image');
+
+        if (typeof productRaw !== 'string' || typeof recipeItemsRaw !== 'string') {
+            throw new Error('Invalid multipart form data');
+        }
+
+        const payload: ProductCreatePayload = {
+            product: JSON.parse(productRaw) as ProduitPayload,
+            recipeItems: JSON.parse(recipeItemsRaw) as RecetteItem[],
+        };
+
+        return { payload, file: file instanceof File ? file : null };
+    }
+
+    const body = await parseJson<ProductCreatePayload>(request);
+    return { payload: body, file: null };
+};
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return methodNotAllowed(['POST']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('products: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    let payload: ProductCreatePayload;
+    let file: File | null;
+    try {
+        const parsed = await parsePayloadFromRequest(request);
+        payload = parsed.payload;
+        file = parsed.file;
+    } catch (error) {
+        console.error('products: payload parsing failed', error);
+        return badRequest('Invalid payload for product creation');
+    }
+
+    if (!payload.product || !payload.product.nom_produit || typeof payload.product.prix_vente !== 'number') {
+        return badRequest('Missing required product fields');
+    }
+
+    if (!Array.isArray(payload.recipeItems)) {
+        return badRequest('Invalid recipe items');
+    }
+
+    try {
+        const { data: productInsert, error: insertError } = await supabase
+            .from('produits')
+            .insert({
+                nom_produit: payload.product.nom_produit,
+                prix_vente: payload.product.prix_vente,
+                categoria_id: payload.product.categoria_id,
+                estado: 'disponible',
+            })
+            .select('id')
+            .maybeSingle();
+
+        if (insertError || !productInsert) {
+            console.error('products: Supabase insert error', insertError);
+            return internalError('Unable to create product');
+        }
+
+        const produitId = productInsert.id as number;
+
+        if (payload.recipeItems.length > 0) {
+            const itemsToInsert = payload.recipeItems.map(item => ({
+                produit_id: produitId,
+                ingredient_id: item.ingredient_id,
+                qte_utilisee: item.qte_utilisee,
+            }));
+
+            const { error: recipeError } = await supabase.from('recette_items').insert(itemsToInsert);
+            if (recipeError) {
+                console.error('products: failed to insert recipe items', recipeError);
+                await supabase.from('produits').delete().eq('id', produitId);
+                return internalError('Unable to save product recipe');
+            }
+        }
+
+        if (file) {
+            try {
+                if (isCloudinaryConfigured()) {
+                    const result = await uploadImageToCloudinary(file, { folder: 'products' });
+                    await supabase
+                        .from('produits')
+                        .update({ image_base64: result.secure_url })
+                        .eq('id', produitId);
+                } else {
+                    const buffer = Buffer.from(await file.arrayBuffer());
+                    const dataUrl = `data:${file.type};base64,${buffer.toString('base64')}`;
+                    await supabase
+                        .from('produits')
+                        .update({ image_base64: dataUrl })
+                        .eq('id', produitId);
+                }
+            } catch (uploadError) {
+                console.error('products: failed to upload product image', uploadError);
+                return internalError('Product created but image upload failed');
+            }
+        }
+
+        try {
+            const produit = await loadProduct(produitId);
+            return jsonResponse(produit, { status: 201 });
+        } catch (fetchError) {
+            console.error('products: failed to reload created product', fetchError);
+            return internalError('Product created but could not be retrieved');
+        }
+    } catch (error) {
+        console.error('products: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/products/recipe.ts
+++ b/netlify/functions/products/recipe.ts
@@ -1,0 +1,72 @@
+import type { Recette, RecetteItem } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed, parseJson } from '../_shared/response';
+
+export const config = { path: '/products/:id/recipe' };
+
+interface RecipePayload {
+    items: RecetteItem[];
+}
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'PUT') {
+        return methodNotAllowed(['PUT']);
+    }
+
+    const url = new URL(request.url);
+    const idParam = url.pathname.split('/').slice(-2)[0];
+    const produitId = Number(idParam);
+
+    if (!produitId || Number.isNaN(produitId)) {
+        return badRequest('Invalid product id');
+    }
+
+    let payload: RecipePayload;
+    try {
+        payload = await parseJson<RecipePayload>(request);
+    } catch (error) {
+        return badRequest('Invalid JSON body');
+    }
+
+    if (!Array.isArray(payload.items)) {
+        return badRequest('Invalid recipe items');
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('products/:id/recipe: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { error: deleteError } = await supabase.from('recette_items').delete().eq('produit_id', produitId);
+        if (deleteError) {
+            console.error('products/:id/recipe: failed to clear existing recipe', deleteError);
+            return internalError('Unable to update recipe');
+        }
+
+        if (payload.items.length > 0) {
+            const itemsToInsert = payload.items.map(item => ({
+                produit_id: produitId,
+                ingredient_id: item.ingredient_id,
+                qte_utilisee: item.qte_utilisee,
+            }));
+            const { error: insertError } = await supabase.from('recette_items').insert(itemsToInsert);
+            if (insertError) {
+                console.error('products/:id/recipe: failed to insert recipe items', insertError);
+                return internalError('Unable to update recipe');
+            }
+        }
+
+        const recette: Recette = {
+            produit_id: produitId,
+            items: payload.items,
+        };
+        return jsonResponse(recette);
+    } catch (error) {
+        console.error('products/:id/recipe: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/products/status.ts
+++ b/netlify/functions/products/status.ts
@@ -1,0 +1,76 @@
+import type { Produit } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed, parseJson } from '../_shared/response';
+import { PRODUCT_SELECT, type ProductRow, mapProductRow } from '../_shared/products';
+
+export const config = { path: '/products/:id/status' };
+
+interface StatusPayload {
+    status: Produit['estado'];
+}
+
+const loadProduct = async (id: number): Promise<Produit> => {
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase
+        .from<ProductRow>('produits')
+        .select(PRODUCT_SELECT)
+        .eq('id', id)
+        .maybeSingle();
+    if (error) {
+        throw new Error(error.message);
+    }
+    if (!data) {
+        throw new Error('Product not found');
+    }
+    return mapProductRow(data);
+};
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'PATCH') {
+        return methodNotAllowed(['PATCH']);
+    }
+
+    const url = new URL(request.url);
+    const idParam = url.pathname.split('/').slice(-2)[0];
+    const produitId = Number(idParam);
+
+    if (!produitId || Number.isNaN(produitId)) {
+        return badRequest('Invalid product id');
+    }
+
+    let payload: StatusPayload;
+    try {
+        payload = await parseJson<StatusPayload>(request);
+    } catch (error) {
+        return badRequest('Invalid JSON body');
+    }
+
+    if (!payload.status) {
+        return badRequest('Missing product status');
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('products/:id/status: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { error } = await supabase
+            .from('produits')
+            .update({ estado: payload.status })
+            .eq('id', produitId);
+        if (error) {
+            console.error('products/:id/status: Supabase update error', error);
+            return internalError('Unable to update product status');
+        }
+
+        const produit = await loadProduct(produitId);
+        return jsonResponse(produit);
+    } catch (error) {
+        console.error('products/:id/status: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/roles.ts
+++ b/netlify/functions/roles.ts
@@ -22,20 +22,15 @@ const createSupabaseClient = () => {
     });
 };
 
-export default async function handler(request: Request): Promise<Response> {
-    if (request.method !== 'GET') {
-        return jsonResponse(
-            { message: 'Method Not Allowed' },
-            {
-                status: 405,
-                headers: {
-                    Allow: 'GET',
-                    'Content-Type': 'application/json',
-                },
-            }
-        );
+const parseJson = async <T>(request: Request): Promise<T> => {
+    try {
+        return (await request.json()) as T;
+    } catch (error) {
+        throw new Error('Invalid JSON body');
     }
+};
 
+export default async function handler(request: Request): Promise<Response> {
     let supabase;
     try {
         supabase = createSupabaseClient();
@@ -44,35 +39,92 @@ export default async function handler(request: Request): Promise<Response> {
         return jsonResponse({ message: 'Server configuration error' }, { status: 500 });
     }
 
-    const url = new URL(request.url);
-    const pin = url.searchParams.get('pin');
+    if (request.method === 'GET') {
+        const url = new URL(request.url);
+        const pin = url.searchParams.get('pin');
 
-    try {
-        if (pin) {
-            const { data, error } = await supabase
-                .from<Role>('roles')
-                .select('*')
-                .eq('pin', pin)
-                .maybeSingle();
+        try {
+            if (pin) {
+                const { data, error } = await supabase
+                    .from<Role>('roles')
+                    .select('*')
+                    .eq('pin', pin)
+                    .maybeSingle();
 
-            if (error) {
-                console.error('roles: Supabase query error (pin filter)', error);
-                return jsonResponse({ message: 'Unable to retrieve role' }, { status: 500 });
+                if (error) {
+                    console.error('roles: Supabase query error (pin filter)', error);
+                    return jsonResponse({ message: 'Unable to retrieve role' }, { status: 500 });
+                }
+
+                return jsonResponse(data ?? null);
             }
 
-            return jsonResponse(data ?? null);
+            const { data, error } = await supabase.from<Role>('roles').select('*');
+
+            if (error) {
+                console.error('roles: Supabase query error', error);
+                return jsonResponse({ message: 'Unable to retrieve roles' }, { status: 500 });
+            }
+
+            return jsonResponse(data ?? []);
+        } catch (error) {
+            console.error('roles: unexpected error', error);
+            return jsonResponse({ message: 'Unexpected server error' }, { status: 500 });
         }
-
-        const { data, error } = await supabase.from<Role>('roles').select('*');
-
-        if (error) {
-            console.error('roles: Supabase query error', error);
-            return jsonResponse({ message: 'Unable to retrieve roles' }, { status: 500 });
-        }
-
-        return jsonResponse(data ?? []);
-    } catch (error) {
-        console.error('roles: unexpected error', error);
-        return jsonResponse({ message: 'Unexpected server error' }, { status: 500 });
     }
+
+    if (request.method === 'POST') {
+        let roles: Role[];
+        try {
+            roles = await parseJson<Role[]>(request);
+        } catch (error) {
+            return jsonResponse({ message: 'Invalid JSON body' }, { status: 400 });
+        }
+
+        if (!Array.isArray(roles)) {
+            return jsonResponse({ message: 'Invalid roles payload' }, { status: 400 });
+        }
+
+        try {
+            const { data: existingRoles, error: readError } = await supabase.from<Role>('roles').select('id');
+            if (readError) {
+                console.error('roles: failed to read existing roles', readError);
+                return jsonResponse({ message: 'Unable to save roles' }, { status: 500 });
+            }
+
+            const { error: upsertError } = await supabase.from<Role>('roles').upsert(roles, { onConflict: 'id' });
+            if (upsertError) {
+                console.error('roles: failed to upsert roles', upsertError);
+                return jsonResponse({ message: 'Unable to save roles' }, { status: 500 });
+            }
+
+            const existingIds = new Set((existingRoles ?? []).map(role => role.id));
+            const incomingIds = new Set(roles.map(role => role.id));
+            const idsToDelete = Array.from(existingIds).filter(id => !incomingIds.has(id));
+
+            if (idsToDelete.length > 0) {
+                const { error: deleteError } = await supabase.from('roles').delete().in('id', idsToDelete);
+                if (deleteError) {
+                    console.error('roles: failed to remove obsolete roles', deleteError);
+                    return jsonResponse({ message: 'Unable to save roles' }, { status: 500 });
+                }
+            }
+
+            return new Response(null, { status: 204 });
+        } catch (error) {
+            console.error('roles: unexpected error while saving', error);
+            return jsonResponse({ message: 'Unexpected server error' }, { status: 500 });
+        }
+    }
+
+    return jsonResponse(
+        { message: 'Method Not Allowed' },
+        {
+            status: 405,
+            headers: {
+                Allow: 'GET, POST',
+                'Content-Type': 'application/json',
+            },
+        }
+    );
 }

--- a/netlify/functions/site-assets.ts
+++ b/netlify/functions/site-assets.ts
@@ -1,0 +1,113 @@
+import { getSupabaseClient } from './_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed, parseJson } from './_shared/response';
+import { generateUploadSignature, isCloudinaryConfigured, uploadImageToCloudinary } from './_shared/cloudinary';
+
+export const config = { path: '/site-assets' };
+
+interface SiteAssetJsonPayload {
+    key: string;
+    data: string;
+}
+
+const getTableName = () => process.env.SUPABASE_SITE_ASSETS_TABLE ?? process.env.VITE_SUPABASE_SITE_ASSETS_TABLE ?? 'site_assets';
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method === 'OPTIONS') {
+        return new Response(null, { status: 204 });
+    }
+
+    if (request.method !== 'PUT') {
+        return methodNotAllowed(['PUT']);
+    }
+
+    const contentType = request.headers.get('content-type') ?? '';
+    const supabase = (() => {
+        try {
+            return getSupabaseClient();
+        } catch (error) {
+            console.error('site-assets: Supabase configuration error', error);
+            throw new Error('Server configuration error');
+        }
+    })();
+
+    const tableName = getTableName();
+
+    try {
+        if (contentType.includes('application/json')) {
+            let payload: SiteAssetJsonPayload;
+            try {
+                payload = await parseJson<SiteAssetJsonPayload>(request);
+            } catch (error) {
+                return badRequest('Invalid JSON body');
+            }
+
+            if (!payload.key || typeof payload.data !== 'string') {
+                return badRequest('Missing asset key or data');
+            }
+
+            const { error } = await supabase
+                .from(tableName)
+                .upsert({ key: payload.key, value: payload.data }, { onConflict: 'key' });
+
+            if (error) {
+                console.error('site-assets: Supabase upsert error', error);
+                return internalError('Unable to save asset');
+            }
+
+            return new Response(null, { status: 204 });
+        }
+
+        const formData = await request.formData();
+        const key = formData.get('key');
+        const file = formData.get('image');
+
+        if (typeof key !== 'string' || !(file instanceof File)) {
+            return badRequest('Missing form fields for asset upload');
+        }
+
+        if (!isCloudinaryConfigured()) {
+            try {
+                const buffer = Buffer.from(await file.arrayBuffer());
+                const dataUrl = `data:${file.type};base64,${buffer.toString('base64')}`;
+                const { error } = await supabase
+                    .from(tableName)
+                    .upsert({ key, value: dataUrl }, { onConflict: 'key' });
+                if (error) {
+                    console.error('site-assets: Supabase upsert error (base64 fallback)', error);
+                    return internalError('Unable to save asset');
+                }
+                return new Response(null, { status: 204 });
+            } catch (error) {
+                console.error('site-assets: base64 fallback failed', error);
+                return internalError();
+            }
+        }
+
+        try {
+            // Ensure signature generation throws early if configuration missing
+            generateUploadSignature();
+        } catch (error) {
+            console.error('site-assets: Cloudinary configuration error', error);
+            return internalError('Media storage is not configured');
+        }
+
+        const uploadResult = await uploadImageToCloudinary(file, { folder: 'site-assets' });
+
+        const { error } = await supabase
+            .from(tableName)
+            .upsert({ key, value: uploadResult.secure_url }, { onConflict: 'key' });
+
+        if (error) {
+            console.error('site-assets: Supabase upsert error (cloudinary)', error);
+            return internalError('Unable to save asset');
+        }
+
+        return jsonResponse({ publicId: uploadResult.public_id, url: uploadResult.secure_url });
+    } catch (error) {
+        if (error instanceof Error && error.message === 'Server configuration error') {
+            return internalError(error.message);
+        }
+        console.error('site-assets: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/tables/id.ts
+++ b/netlify/functions/tables/id.ts
@@ -1,0 +1,74 @@
+import type { TablePayload } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed, parseJson } from '../_shared/response';
+
+export const config = { path: '/tables/:id' };
+
+export default async function handler(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const idParam = url.pathname.split('/').pop();
+    const id = Number(idParam);
+
+    if (!id || Number.isNaN(id)) {
+        return badRequest('Invalid table id');
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('tables/:id: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    if (request.method === 'PUT') {
+        let payload: Omit<TablePayload, 'id'>;
+        try {
+            payload = await parseJson<Omit<TablePayload, 'id'>>(request);
+        } catch (error) {
+            return badRequest('Invalid JSON body');
+        }
+
+        if (!payload.nom || typeof payload.capacite !== 'number') {
+            return badRequest('Missing required table fields');
+        }
+
+        try {
+            const { data, error } = await supabase
+                .from('tables')
+                .update({
+                    nom: payload.nom,
+                    capacite: payload.capacite,
+                })
+                .eq('id', id)
+                .select('id, nom, capacite, statut')
+                .maybeSingle();
+
+            if (error) {
+                console.error('tables/:id: Supabase update error', error);
+                return internalError('Unable to update table');
+            }
+
+            return jsonResponse(data ?? null);
+        } catch (error) {
+            console.error('tables/:id: unexpected update error', error);
+            return internalError();
+        }
+    }
+
+    if (request.method === 'DELETE') {
+        try {
+            const { error } = await supabase.from('tables').delete().eq('id', id);
+            if (error) {
+                console.error('tables/:id: Supabase delete error', error);
+                return internalError('Unable to delete table');
+            }
+            return new Response(null, { status: 204 });
+        } catch (error) {
+            console.error('tables/:id: unexpected delete error', error);
+            return internalError();
+        }
+    }
+
+    return methodNotAllowed(['PUT', 'DELETE']);
+}

--- a/netlify/functions/tables/index.ts
+++ b/netlify/functions/tables/index.ts
@@ -1,0 +1,53 @@
+import type { TablePayload } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed, parseJson } from '../_shared/response';
+
+export const config = { path: '/tables' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return methodNotAllowed(['POST']);
+    }
+
+    let payload: TablePayload;
+    try {
+        payload = await parseJson<TablePayload>(request);
+    } catch (error) {
+        return badRequest('Invalid JSON body');
+    }
+
+    if (!payload.id || !payload.nom || typeof payload.capacite !== 'number') {
+        return badRequest('Missing required table fields');
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('tables: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from('tables')
+            .insert({
+                id: payload.id,
+                nom: payload.nom,
+                capacite: payload.capacite,
+                statut: 'libre',
+            })
+            .select('id, nom, capacite, statut')
+            .maybeSingle();
+
+        if (error) {
+            console.error('tables: Supabase insert error', error);
+            return internalError('Unable to create table');
+        }
+
+        return jsonResponse(data, { status: 201 });
+    } catch (error) {
+        console.error('tables: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/takeaway/pending.ts
+++ b/netlify/functions/takeaway/pending.ts
@@ -1,0 +1,40 @@
+import type { Commande } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+import { COMMANDE_SELECT, type CommandeRow, mapCommandeRow } from '../_shared/commandes';
+
+export const config = { path: '/takeaway/pending' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'GET') {
+        return methodNotAllowed(['GET']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('takeaway/pending: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from<CommandeRow>('commandes')
+            .select(COMMANDE_SELECT)
+            .eq('statut', 'pendiente_validacion')
+            .is('table_id', null)
+            .order('date_creation', { ascending: true });
+
+        if (error) {
+            console.error('takeaway/pending: Supabase query error', error);
+            return internalError('Unable to retrieve takeaway orders');
+        }
+
+        const commandes: Commande[] = (data ?? []).map(mapCommandeRow);
+        return jsonResponse(commandes);
+    } catch (error) {
+        console.error('takeaway/pending: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/takeaway/ready.ts
+++ b/netlify/functions/takeaway/ready.ts
@@ -1,0 +1,40 @@
+import type { Commande } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+import { COMMANDE_SELECT, type CommandeRow, mapCommandeRow } from '../_shared/commandes';
+
+export const config = { path: '/takeaway/ready' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'GET') {
+        return methodNotAllowed(['GET']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('takeaway/ready: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from<CommandeRow>('commandes')
+            .select(COMMANDE_SELECT)
+            .eq('statut', 'en_cours')
+            .is('table_id', null)
+            .order('date_creation', { ascending: true });
+
+        if (error) {
+            console.error('takeaway/ready: Supabase query error', error);
+            return internalError('Unable to retrieve takeaway orders');
+        }
+
+        const commandes: Commande[] = (data ?? []).map(mapCommandeRow);
+        return jsonResponse(commandes);
+    } catch (error) {
+        console.error('takeaway/ready: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/takeaway/submit.ts
+++ b/netlify/functions/takeaway/submit.ts
@@ -1,0 +1,95 @@
+import type { Commande, CommandeItem } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { badRequest, internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+import { COMMANDE_SELECT, type CommandeRow, mapCommandeRow } from '../_shared/commandes';
+import { isCloudinaryConfigured, uploadImageToCloudinary } from '../_shared/cloudinary';
+
+export const config = { path: '/takeaway/submit' };
+
+const loadCommande = async (id: string): Promise<Commande> => {
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase
+        .from<CommandeRow>('commandes')
+        .select(COMMANDE_SELECT)
+        .eq('id', id)
+        .maybeSingle();
+    if (error) {
+        throw new Error(error.message);
+    }
+    if (!data) {
+        throw new Error('Commande not found');
+    }
+    return mapCommandeRow(data);
+};
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return methodNotAllowed(['POST']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('takeaway/submit: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const formData = await request.formData();
+        const itemsRaw = formData.get('items');
+        const fullName = formData.get('fullName');
+        const address = formData.get('address');
+        const paymentMethod = formData.get('paymentMethod');
+        const receipt = formData.get('receipt');
+
+        if (typeof itemsRaw !== 'string' || typeof fullName !== 'string' || typeof address !== 'string' || typeof paymentMethod !== 'string') {
+            return badRequest('Missing takeaway order fields');
+        }
+
+        const items = JSON.parse(itemsRaw) as CommandeItem[];
+        if (!Array.isArray(items)) {
+            return badRequest('Invalid commande items');
+        }
+
+        let receiptData: string | undefined;
+        if (receipt instanceof File) {
+            if (isCloudinaryConfigured()) {
+                const result = await uploadImageToCloudinary(receipt, { folder: 'receipts' });
+                receiptData = result.secure_url;
+            } else {
+                const buffer = Buffer.from(await receipt.arrayBuffer());
+                receiptData = `data:${receipt.type};base64,${buffer.toString('base64')}`;
+            }
+        }
+
+        const { data, error } = await supabase
+            .from('commandes')
+            .insert({
+                table_id: null,
+                couverts: 0,
+                statut: 'pendiente_validacion',
+                date_creation: new Date().toISOString(),
+                items,
+                estado_cocina: null,
+                payment_status: 'impaye',
+                customer_name: fullName,
+                customer_address: address,
+                payment_method: paymentMethod,
+                receipt_image_base64: receiptData ?? null,
+            })
+            .select('id')
+            .maybeSingle();
+
+        if (error || !data) {
+            console.error('takeaway/submit: Supabase insert error', error);
+            return internalError('Unable to submit takeaway order');
+        }
+
+        const commande = await loadCommande(data.id as string);
+        return jsonResponse(commande, { status: 201 });
+    } catch (error) {
+        console.error('takeaway/submit: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/takeaway/validate.ts
+++ b/netlify/functions/takeaway/validate.ts
@@ -1,0 +1,42 @@
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/takeaway/validate/:id' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+        return methodNotAllowed(['POST']);
+    }
+
+    const url = new URL(request.url);
+    const commandeId = url.pathname.split('/').pop();
+
+    if (!commandeId) {
+        return jsonResponse({ message: 'Invalid commande id' }, { status: 400 });
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('takeaway/validate: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    const now = new Date().toISOString();
+
+    try {
+        const { error } = await supabase
+            .from('commandes')
+            .update({ statut: 'en_cours', estado_cocina: 'recibido', date_envoi_cuisine: now, date_dernier_envoi_cuisine: now })
+            .eq('id', commandeId);
+        if (error) {
+            console.error('takeaway/validate: Supabase update error', error);
+            return internalError('Unable to validate takeaway order');
+        }
+        return new Response(null, { status: 204 });
+    } catch (error) {
+        console.error('takeaway/validate: unexpected error', error);
+        return internalError();
+    }
+}

--- a/netlify/functions/time-tracking/entries.ts
+++ b/netlify/functions/time-tracking/entries.ts
@@ -1,0 +1,36 @@
+import type { TimeEntry } from '../../../types';
+import { getSupabaseClient } from '../_shared/supabase';
+import { internalError, jsonResponse, methodNotAllowed } from '../_shared/response';
+
+export const config = { path: '/time-tracking/entries' };
+
+export default async function handler(request: Request): Promise<Response> {
+    if (request.method !== 'GET') {
+        return methodNotAllowed(['GET']);
+    }
+
+    let supabase;
+    try {
+        supabase = getSupabaseClient();
+    } catch (error) {
+        console.error('time-tracking/entries: Supabase configuration error', error);
+        return internalError('Server configuration error');
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from<TimeEntry>('time_entries')
+            .select('*')
+            .order('timestamp', { ascending: false });
+
+        if (error) {
+            console.error('time-tracking/entries: Supabase query error', error);
+            return internalError('Unable to retrieve time entries');
+        }
+
+        return jsonResponse(data ?? []);
+    } catch (error) {
+        console.error('time-tracking/entries: unexpected error', error);
+        return internalError();
+    }
+}


### PR DESCRIPTION
## Summary
- add shared Supabase, response, and Cloudinary helpers for Netlify functions
- implement data, catalog, order, kitchen, takeaway, and site asset handlers matching apiService endpoints
- extend roles function to support persistence updates and expose time-tracking endpoint

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ceb580dcfc832a808c68b5090dc86d