### PR TITLE
Configure local Tailwind build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "recharts": "^3.1.2"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.1.13",
     "@types/node": "^22.14.0",
+    "@tailwindcss/postcss": "^4.1.13",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.13",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
 export default {
   plugins: {
     '@tailwindcss/postcss': {},
+    autoprefixer: {},
   },
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,4 @@
-import type { Config } from 'tailwindcss';
-
+/** @type {import('tailwindcss').Config} */
 export default {
   content: [
     './index.html',
@@ -16,4 +15,4 @@ export default {
     extend: {},
   },
   plugins: [],
-} satisfies Config;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,21 @@ export default defineConfig(({ mode }) => {
         alias: {
           '@': path.resolve(__dirname, '.'),
         }
-      }
+      },
+      build: {
+        chunkSizeWarningLimit: 1024,
+        rollupOptions: {
+          onwarn(warning, defaultHandler) {
+            if (
+              warning.code === 'MODULE_LEVEL_DIRECTIVE' &&
+              typeof warning.message === 'string' &&
+              warning.message.includes('"use client"')
+            ) {
+              return;
+            }
+            defaultHandler(warning);
+          },
+        },
+      },
     };
 });


### PR DESCRIPTION
## Summary
- expose a JavaScript Tailwind configuration so the project picks up local styles
- update the PostCSS pipeline to run Tailwind via the local plugin together with autoprefixer
- tweak the Vite build settings to keep the production build free of noise from third-party warnings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cebcef2d48832a8273d0cb1b4e7509