### PR TITLE
Remove import map override for Recharts

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
           "react": "https://aistudiocdn.com/react@^19.1.1",
           "react-dom/": "https://aistudiocdn.com/react-dom@^19.1.1/",
           "lucide-react": "https://aistudiocdn.com/lucide-react@^0.542.0",
-          "recharts": "https://aistudiocdn.com/recharts@^3.1.2",
           "react-router-dom": "https://aistudiocdn.com/react-router-dom@^7.8.2"
         }
       }


### PR DESCRIPTION
## Summary
- remove the CDN import map entry for Recharts so Vite resolves the package from node_modules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cec8f599dc832abc96958a3ef97c69