### PR TITLE
Add CSP guard for Recharts bundle

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
           "react": "https://aistudiocdn.com/react@^19.1.1",
           "react-dom/": "https://aistudiocdn.com/react-dom@^19.1.1/",
           "lucide-react": "https://aistudiocdn.com/lucide-react@^0.542.0",
-          "recharts": "https://aistudiocdn.com/recharts@^3.1.2",
           "react-router-dom": "https://aistudiocdn.com/react-router-dom@^7.8.2"
         }
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "check:csp": "node scripts/checkUnsafeEval.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.48.0",

--- a/scripts/checkUnsafeEval.mjs
+++ b/scripts/checkUnsafeEval.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const distDir = path.resolve(process.cwd(), 'dist');
+
+async function ensureDistExists() {
+  try {
+    const dirStats = await stat(distDir);
+    if (!dirStats.isDirectory()) {
+      console.error(`Expected \"${distDir}\" to be a directory with build artifacts.`);
+      process.exit(1);
+    }
+  } catch (error) {
+    if (error && (error.code === 'ENOENT' || error.code === 'ENOTDIR')) {
+      console.error('Build output not found. Run `npm run build` before running this check.');
+      process.exit(1);
+    }
+    console.error('Unable to read build output directory:', error);
+    process.exit(1);
+  }
+}
+
+async function collectJsFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectJsFiles(fullPath)));
+    } else if (entry.isFile() && /\.(js|mjs|cjs)$/i.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+async function main() {
+  await ensureDistExists();
+  const jsFiles = await collectJsFiles(distDir);
+  if (jsFiles.length === 0) {
+    console.warn('No JavaScript bundles were found in the build output to scan.');
+    process.exit(0);
+  }
+
+  const offenders = [];
+  const pattern = 'new Function';
+
+  for (const file of jsFiles) {
+    const content = await readFile(file, 'utf8');
+    if (content.includes(pattern)) {
+      offenders.push(file);
+    }
+  }
+
+  if (offenders.length > 0) {
+    console.error('Found unsafe-eval patterns in the bundled output:');
+    for (const offender of offenders) {
+      console.error(` - ${offender}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Scanned ${jsFiles.length} JavaScript bundle(s); no \"${pattern}\" occurrences detected.`);
+}
+
+await main();


### PR DESCRIPTION
## Summary
- add a reusable script that scans the production bundle for `new Function` occurrences to guard against CSP regressions
- expose the check via an npm script so it can be invoked alongside the build

## Testing
- npm run build
- npm run check:csp

------
https://chatgpt.com/codex/tasks/task_b_68cec8f599dc832abc96958a3ef97c69