### PR TITLE
Prepare project for Netlify deployment

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HashRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { DataProvider } from './hooks/useRestaurantData';
 import Layout from './components/Layout';
 import Dashboard from './pages/Dashboard';
@@ -56,11 +56,11 @@ const AppRoutes: React.FC = () => {
 const App: React.FC = () => {
   return (
     <DataProvider>
-      <HashRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Routes>
           <Route path="/login" element={<Login />} />
           <Route path="/commande-client" element={<CustomerOrder />} />
-          <Route 
+          <Route
             path="/*"
             element={
               <ProtectedRoute>
@@ -71,7 +71,7 @@ const App: React.FC = () => {
             }
           />
         </Routes>
-      </HashRouter>
+      </BrowserRouter>
     </DataProvider>
   );
 };

--- a/index.html
+++ b/index.html
@@ -12,17 +12,6 @@
       href="https://fonts.googleapis.com/css2?family=Lilita+One&amp;display=swap"
       rel="stylesheet"
     />
-    <script type="importmap">
-      {
-        "imports": {
-          "react/": "https://aistudiocdn.com/react@^19.1.1/",
-          "react": "https://aistudiocdn.com/react@^19.1.1",
-          "react-dom/": "https://aistudiocdn.com/react-dom@^19.1.1/",
-          "lucide-react": "https://aistudiocdn.com/lucide-react@^0.542.0",
-          "react-router-dom": "https://aistudiocdn.com/react-router-dom@^7.8.2"
-        }
-      }
-    </script>
   </head>
   <body class="bg-gray-100 dark:bg-gray-900">
     <div id="root"></div>

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,0 @@
-{
-  "name": "OUIOUI",
-  "description": "Una aplicación web completa para ayudar a los restauradores a gestionar ingredientes, recetas, ventas, compras y analizar su rendimiento financiero con paneles e informes detallados.",
-  "requestFramePermissions": []
-}

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,8 @@
 
 [context.production.environment]
   VITE_NETLIFY_FUNCTIONS_BASE = "/.netlify/functions"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,32 +1,25 @@
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 
-export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
-    return {
-      define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
-      },
-      resolve: {
+export default defineConfig({
+    resolve: {
         alias: {
-          '@': path.resolve(__dirname, '.'),
-        }
-      },
-      build: {
+            '@': path.resolve(__dirname, '.'),
+        },
+    },
+    build: {
         chunkSizeWarningLimit: 1024,
         rollupOptions: {
-          onwarn(warning, defaultHandler) {
-            if (
-              warning.code === 'MODULE_LEVEL_DIRECTIVE' &&
-              typeof warning.message === 'string' &&
-              warning.message.includes('"use client"')
-            ) {
-              return;
-            }
-            defaultHandler(warning);
-          },
+            onwarn(warning, defaultHandler) {
+                if (
+                    warning.code === 'MODULE_LEVEL_DIRECTIVE' &&
+                    typeof warning.message === 'string' &&
+                    warning.message.includes('"use client"')
+                ) {
+                    return;
+                }
+                defaultHandler(warning);
+            },
         },
-      },
-    };
+    },
 });


### PR DESCRIPTION
## Summary
- replace the HashRouter with BrowserRouter so routes behave correctly on Netlify and remove the Google AI Studio metadata
- drop the Google-specific import map and simplify the Vite config now that dependencies are bundled locally
- add a SPA redirect rule to `netlify.toml` for Netlify deployments

## Testing
- npm run build
- npm run check:csp

------
https://chatgpt.com/codex/tasks/task_b_68ced3de0570832aac1540cb20b197b3