### PR TITLE
Fix Supabase typings for Netlify build

### DIFF
--- a/netlify/functions/auth-login.ts
+++ b/netlify/functions/auth-login.ts
@@ -59,7 +59,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const { data, error } = await supabase
-            .from<Role>('roles')
+            .from('roles')
             .select('*')
             .eq('pin', pin)
             .maybeSingle();
@@ -69,7 +69,8 @@ export default async function handler(request: Request): Promise<Response> {
             return jsonResponse({ message: 'Unable to complete authentication' }, { status: 500 });
         }
 
-        return jsonResponse(data ?? null);
+        const role = data as Role | null;
+        return jsonResponse(role ?? null);
     } catch (error) {
         console.error('auth-login: unexpected error', error);
         return jsonResponse({ message: 'Unexpected server error' }, { status: 500 });

--- a/netlify/functions/categories/index.ts
+++ b/netlify/functions/categories/index.ts
@@ -34,7 +34,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const { data, error } = await supabase
-            .from<Categoria>('categories')
+            .from('categories')
             .insert({ nom: payload.nom })
             .select('*')
             .maybeSingle();
@@ -44,11 +44,13 @@ export default async function handler(request: Request): Promise<Response> {
             return internalError('Unable to create category');
         }
 
-        if (!data) {
+        const category = data as Categoria | null;
+
+        if (!category) {
             return internalError('Category creation failed');
         }
 
-        return jsonResponse(data, { status: 201 });
+        return jsonResponse(category, { status: 201 });
     } catch (error) {
         console.error('categories: unexpected error', error);
         return internalError();

--- a/netlify/functions/commandes/active.ts
+++ b/netlify/functions/commandes/active.ts
@@ -20,7 +20,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const { data, error } = await supabase
-            .from<CommandeRow>('commandes')
+            .from('commandes')
             .select(COMMANDE_SELECT)
             .in('statut', ['en_cours', 'pendiente_validacion']);
 
@@ -29,7 +29,8 @@ export default async function handler(request: Request): Promise<Response> {
             return internalError('Unable to retrieve commandes');
         }
 
-        const commandes: Commande[] = (data ?? []).map(mapCommandeRow);
+        const rows = (data ?? []) as CommandeRow[];
+        const commandes: Commande[] = rows.map(mapCommandeRow);
         return jsonResponse(commandes);
     } catch (error) {
         console.error('commandes/active: unexpected error', error);

--- a/netlify/functions/commandes/id.ts
+++ b/netlify/functions/commandes/id.ts
@@ -13,17 +13,18 @@ interface UpdateCommandePayload {
 const loadCommande = async (id: string): Promise<Commande> => {
     const supabase = getSupabaseClient();
     const { data, error } = await supabase
-        .from<CommandeRow>('commandes')
+        .from('commandes')
         .select(COMMANDE_SELECT)
         .eq('id', id)
         .maybeSingle();
     if (error) {
         throw new Error(error.message);
     }
-    if (!data) {
+    const row = data as CommandeRow | null;
+    if (!row) {
         throw new Error('Commande not found');
     }
-    return mapCommandeRow(data);
+    return mapCommandeRow(row);
 };
 
 export default async function handler(request: Request): Promise<Response> {

--- a/netlify/functions/commandes/index.ts
+++ b/netlify/functions/commandes/index.ts
@@ -13,14 +13,15 @@ interface CreateCommandePayload {
 const loadCommandeById = async (id: string): Promise<Commande | null> => {
     const supabase = getSupabaseClient();
     const { data, error } = await supabase
-        .from<CommandeRow>('commandes')
+        .from('commandes')
         .select(COMMANDE_SELECT)
         .eq('id', id)
         .maybeSingle();
     if (error) {
         throw new Error(error.message);
     }
-    return data ? mapCommandeRow(data) : null;
+    const row = data as CommandeRow | null;
+    return row ? mapCommandeRow(row) : null;
 };
 
 export default async function handler(request: Request): Promise<Response> {
@@ -49,7 +50,7 @@ export default async function handler(request: Request): Promise<Response> {
                     return badRequest('Invalid table id');
                 }
                 const { data, error } = await supabase
-                    .from<CommandeRow>('commandes')
+                    .from('commandes')
                     .select(COMMANDE_SELECT)
                     .eq('table_id', tableId)
                     .in('statut', ['en_cours', 'pendiente_validacion'])
@@ -58,7 +59,8 @@ export default async function handler(request: Request): Promise<Response> {
                     console.error('commandes: failed to fetch by table id', error);
                     return internalError('Unable to retrieve commande');
                 }
-                return jsonResponse(data ? mapCommandeRow(data) : null);
+                const row = data as CommandeRow | null;
+                return jsonResponse(row ? mapCommandeRow(row) : null);
             }
 
             return badRequest('Missing lookup parameters');

--- a/netlify/functions/data/categories.ts
+++ b/netlify/functions/data/categories.ts
@@ -19,7 +19,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const { data, error } = await supabase
-            .from<Categoria>('categories')
+            .from('categories')
             .select('*')
             .order('nom', { ascending: true });
 
@@ -28,7 +28,8 @@ export default async function handler(request: Request): Promise<Response> {
             return internalError('Unable to retrieve categories');
         }
 
-        return jsonResponse(data ?? []);
+        const rows = (data ?? []) as Categoria[];
+        return jsonResponse(rows);
     } catch (error) {
         console.error('data/categories: unexpected error', error);
         return internalError();

--- a/netlify/functions/data/ingredients.ts
+++ b/netlify/functions/data/ingredients.ts
@@ -20,7 +20,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const { data, error } = await supabase
-            .from<IngredientRow>('ingredients')
+            .from('ingredients')
             .select(INGREDIENT_SELECT)
             .order('nom', { ascending: true });
 
@@ -29,7 +29,8 @@ export default async function handler(request: Request): Promise<Response> {
             return internalError('Unable to retrieve ingredients');
         }
 
-        const ingredients: Ingredient[] = (data ?? []).map(mapIngredientRow);
+        const rows = (data ?? []) as IngredientRow[];
+        const ingredients: Ingredient[] = rows.map(mapIngredientRow);
 
         return jsonResponse(ingredients);
     } catch (error) {

--- a/netlify/functions/data/products.ts
+++ b/netlify/functions/data/products.ts
@@ -28,7 +28,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const { data, error } = await supabase
-            .from<ProduitRow>('produits')
+            .from('produits')
             .select('id, nom_produit, prix_vente, categoria_id, estado, image_base64')
             .order('nom_produit', { ascending: true });
 
@@ -37,7 +37,8 @@ export default async function handler(request: Request): Promise<Response> {
             return internalError('Unable to retrieve products');
         }
 
-        const produits: Produit[] = (data ?? []).map(row => ({
+        const rows = (data ?? []) as ProduitRow[];
+        const produits: Produit[] = rows.map(row => ({
             id: row.id,
             nom_produit: row.nom_produit,
             prix_vente: row.prix_vente,

--- a/netlify/functions/data/purchases.ts
+++ b/netlify/functions/data/purchases.ts
@@ -19,7 +19,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const { data, error } = await supabase
-            .from<Achat>('achats')
+            .from('achats')
             .select('*')
             .order('date_achat', { ascending: false });
 
@@ -28,7 +28,8 @@ export default async function handler(request: Request): Promise<Response> {
             return internalError('Unable to retrieve purchases');
         }
 
-        return jsonResponse(data ?? []);
+        const rows = (data ?? []) as Achat[];
+        return jsonResponse(rows);
     } catch (error) {
         console.error('data/purchases: unexpected error', error);
         return internalError();

--- a/netlify/functions/data/recipes.ts
+++ b/netlify/functions/data/recipes.ts
@@ -25,7 +25,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const { data, error } = await supabase
-            .from<RecetteItemRow>('recette_items')
+            .from('recette_items')
             .select('produit_id, ingredient_id, qte_utilisee')
             .order('produit_id', { ascending: true });
 
@@ -35,7 +35,8 @@ export default async function handler(request: Request): Promise<Response> {
         }
 
         const recettesMap = new Map<number, RecetteItem[]>();
-        for (const row of data ?? []) {
+        const rows = (data ?? []) as RecetteItemRow[];
+        for (const row of rows) {
             if (!recettesMap.has(row.produit_id)) {
                 recettesMap.set(row.produit_id, []);
             }

--- a/netlify/functions/data/sales.ts
+++ b/netlify/functions/data/sales.ts
@@ -19,7 +19,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const { data, error } = await supabase
-            .from<Vente>('ventes')
+            .from('ventes')
             .select('*')
             .order('date_vente', { ascending: false });
 
@@ -28,7 +28,8 @@ export default async function handler(request: Request): Promise<Response> {
             return internalError('Unable to retrieve sales');
         }
 
-        return jsonResponse(data ?? []);
+        const rows = (data ?? []) as Vente[];
+        return jsonResponse(rows);
     } catch (error) {
         console.error('data/sales: unexpected error', error);
         return internalError();

--- a/netlify/functions/data/site-assets.ts
+++ b/netlify/functions/data/site-assets.ts
@@ -23,14 +23,15 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const tableName = process.env.SUPABASE_SITE_ASSETS_TABLE ?? process.env.VITE_SUPABASE_SITE_ASSETS_TABLE ?? 'site_assets';
-        const { data, error } = await supabase.from<SiteAssetRow>(tableName).select('key, value');
+        const { data, error } = await supabase.from(tableName).select('key, value');
 
         if (error) {
             console.error('data/site-assets: Supabase query error', error);
             return internalError('Unable to retrieve site assets');
         }
 
-        const assets = (data ?? []).reduce<Record<string, string>>((acc, row) => {
+        const rows = (data ?? []) as SiteAssetRow[];
+        const assets = rows.reduce<Record<string, string>>((acc, row) => {
             acc[row.key] = row.value;
             return acc;
         }, {});

--- a/netlify/functions/data/tables.ts
+++ b/netlify/functions/data/tables.ts
@@ -34,7 +34,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const { data, error } = await supabase
-            .from<TableRow>('tables')
+            .from('tables')
             .select(
                 'id, nom, capacite, statut, commande_id, couverts, total_commande, is_ready, ready_timestamp, creation_timestamp, sent_to_kitchen_timestamp, kitchen_status'
             )
@@ -45,7 +45,8 @@ export default async function handler(request: Request): Promise<Response> {
             return internalError('Unable to retrieve tables');
         }
 
-        const tables: Table[] = (data ?? []).map(row => ({
+        const rows = (data ?? []) as TableRow[];
+        const tables: Table[] = rows.map(row => ({
             id: row.id,
             nom: row.nom,
             capacite: row.capacite,

--- a/netlify/functions/ingredients/id.ts
+++ b/netlify/functions/ingredients/id.ts
@@ -8,17 +8,18 @@ export const config = { path: '/ingredients/:id' };
 const loadIngredient = async (id: number): Promise<Ingredient> => {
     const supabase = getSupabaseClient();
     const { data, error } = await supabase
-        .from<IngredientRow>('ingredients')
+        .from('ingredients')
         .select(INGREDIENT_SELECT)
         .eq('id', id)
         .maybeSingle();
     if (error) {
         throw new Error(error.message);
     }
-    if (!data) {
+    const row = data as IngredientRow | null;
+    if (!row) {
         throw new Error('Ingredient not found');
     }
-    return mapIngredientRow(data);
+    return mapIngredientRow(row);
 };
 
 export default async function handler(request: Request): Promise<Response> {

--- a/netlify/functions/ingredients/index.ts
+++ b/netlify/functions/ingredients/index.ts
@@ -8,7 +8,7 @@ export const config = { path: '/ingredients' };
 const fetchIngredientById = async (id: number) => {
     const supabase = getSupabaseClient();
     const { data, error } = await supabase
-        .from<IngredientRow>('ingredients')
+        .from('ingredients')
         .select(INGREDIENT_SELECT)
         .eq('id', id)
         .maybeSingle();
@@ -17,11 +17,13 @@ const fetchIngredientById = async (id: number) => {
         throw new Error(error.message);
     }
 
-    if (!data) {
+    const row = data as IngredientRow | null;
+
+    if (!row) {
         throw new Error('Ingredient not found');
     }
 
-    return mapIngredientRow(data);
+    return mapIngredientRow(row);
 };
 
 export default async function handler(request: Request): Promise<Response> {

--- a/netlify/functions/ingredients/purchase.ts
+++ b/netlify/functions/ingredients/purchase.ts
@@ -53,7 +53,7 @@ export default async function handler(request: Request): Promise<Response> {
         }
 
         const { data, error } = await supabase
-            .from<Achat>('achats')
+            .from('achats')
             .insert({
                 ingredient_id,
                 quantite_achetee,
@@ -68,11 +68,13 @@ export default async function handler(request: Request): Promise<Response> {
             return internalError('Unable to record purchase');
         }
 
-        if (!data) {
+        const achat = data as Achat | null;
+
+        if (!achat) {
             return internalError('Purchase was not recorded');
         }
 
-        return jsonResponse(data, { status: 201 });
+        return jsonResponse(achat, { status: 201 });
     } catch (error) {
         console.error('ingredients/purchase: unexpected error', error);
         return internalError();

--- a/netlify/functions/kitchen/orders.ts
+++ b/netlify/functions/kitchen/orders.ts
@@ -20,7 +20,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const { data, error } = await supabase
-            .from<CommandeRow>('commandes')
+            .from('commandes')
             .select(COMMANDE_SELECT)
             .in('statut', ['en_cours', 'pendiente_validacion'])
             .order('date_creation', { ascending: true });
@@ -30,7 +30,8 @@ export default async function handler(request: Request): Promise<Response> {
             return internalError('Unable to retrieve kitchen orders');
         }
 
-        const commandes: Commande[] = (data ?? []).map(mapCommandeRow);
+        const rows = (data ?? []) as CommandeRow[];
+        const commandes: Commande[] = rows.map(mapCommandeRow);
         return jsonResponse(commandes);
     } catch (error) {
         console.error('kitchen/orders: unexpected error', error);

--- a/netlify/functions/products/id.ts
+++ b/netlify/functions/products/id.ts
@@ -8,17 +8,18 @@ export const config = { path: '/products/:id' };
 const loadProduct = async (id: number): Promise<Produit> => {
     const supabase = getSupabaseClient();
     const { data, error } = await supabase
-        .from<ProductRow>('produits')
+        .from('produits')
         .select(PRODUCT_SELECT)
         .eq('id', id)
         .maybeSingle();
     if (error) {
         throw new Error(error.message);
     }
-    if (!data) {
+    const row = data as ProductRow | null;
+    if (!row) {
         throw new Error('Product not found');
     }
-    return mapProductRow(data);
+    return mapProductRow(row);
 };
 
 export default async function handler(request: Request): Promise<Response> {

--- a/netlify/functions/products/image.ts
+++ b/netlify/functions/products/image.ts
@@ -9,17 +9,18 @@ export const config = { path: '/products/:id/image' };
 const loadProduct = async (id: number): Promise<Produit> => {
     const supabase = getSupabaseClient();
     const { data, error } = await supabase
-        .from<ProductRow>('produits')
+        .from('produits')
         .select(PRODUCT_SELECT)
         .eq('id', id)
         .maybeSingle();
     if (error) {
         throw new Error(error.message);
     }
-    if (!data) {
+    const row = data as ProductRow | null;
+    if (!row) {
         throw new Error('Product not found');
     }
-    return mapProductRow(data);
+    return mapProductRow(row);
 };
 
 export default async function handler(request: Request): Promise<Response> {

--- a/netlify/functions/products/index.ts
+++ b/netlify/functions/products/index.ts
@@ -14,17 +14,18 @@ interface ProductCreatePayload {
 const loadProduct = async (id: number): Promise<Produit> => {
     const supabase = getSupabaseClient();
     const { data, error } = await supabase
-        .from<ProductRow>('produits')
+        .from('produits')
         .select(PRODUCT_SELECT)
         .eq('id', id)
         .maybeSingle();
     if (error) {
         throw new Error(error.message);
     }
-    if (!data) {
+    const row = data as ProductRow | null;
+    if (!row) {
         throw new Error('Product not found');
     }
-    return mapProductRow(data);
+    return mapProductRow(row);
 };
 
 const parsePayloadFromRequest = async (request: Request): Promise<{ payload: ProductCreatePayload; file: File | null }> => {

--- a/netlify/functions/products/status.ts
+++ b/netlify/functions/products/status.ts
@@ -12,17 +12,18 @@ interface StatusPayload {
 const loadProduct = async (id: number): Promise<Produit> => {
     const supabase = getSupabaseClient();
     const { data, error } = await supabase
-        .from<ProductRow>('produits')
+        .from('produits')
         .select(PRODUCT_SELECT)
         .eq('id', id)
         .maybeSingle();
     if (error) {
         throw new Error(error.message);
     }
-    if (!data) {
+    const row = data as ProductRow | null;
+    if (!row) {
         throw new Error('Product not found');
     }
-    return mapProductRow(data);
+    return mapProductRow(row);
 };
 
 export default async function handler(request: Request): Promise<Response> {

--- a/netlify/functions/roles.ts
+++ b/netlify/functions/roles.ts
@@ -46,7 +46,7 @@ export default async function handler(request: Request): Promise<Response> {
         try {
             if (pin) {
                 const { data, error } = await supabase
-                    .from<Role>('roles')
+                    .from('roles')
                     .select('*')
                     .eq('pin', pin)
                     .maybeSingle();
@@ -56,17 +56,19 @@ export default async function handler(request: Request): Promise<Response> {
                     return jsonResponse({ message: 'Unable to retrieve role' }, { status: 500 });
                 }
 
-                return jsonResponse(data ?? null);
+                const role = data as Role | null;
+                return jsonResponse(role ?? null);
             }
 
-            const { data, error } = await supabase.from<Role>('roles').select('*');
+            const { data, error } = await supabase.from('roles').select('*');
 
             if (error) {
                 console.error('roles: Supabase query error', error);
                 return jsonResponse({ message: 'Unable to retrieve roles' }, { status: 500 });
             }
 
-            return jsonResponse(data ?? []);
+            const rolesData = (data ?? []) as Role[];
+            return jsonResponse(rolesData);
         } catch (error) {
             console.error('roles: unexpected error', error);
             return jsonResponse({ message: 'Unexpected server error' }, { status: 500 });
@@ -86,20 +88,20 @@ export default async function handler(request: Request): Promise<Response> {
         }
 
         try {
-            const { data: existingRoles, error: readError } = await supabase.from<Role>('roles').select('id');
+            const { data: existingRoles, error: readError } = await supabase.from('roles').select('id');
             if (readError) {
                 console.error('roles: failed to read existing roles', readError);
                 return jsonResponse({ message: 'Unable to save roles' }, { status: 500 });
             }
 
-            const { error: upsertError } = await supabase.from<Role>('roles').upsert(roles, { onConflict: 'id' });
+            const { error: upsertError } = await supabase.from('roles').upsert(roles, { onConflict: 'id' });
             if (upsertError) {
                 console.error('roles: failed to upsert roles', upsertError);
                 return jsonResponse({ message: 'Unable to save roles' }, { status: 500 });
             }
 
-            const existingIds = new Set((existingRoles ?? []).map(role => role.id));
-            const incomingIds = new Set(roles.map(role => role.id));
+            const existingIds = new Set<string>(((existingRoles ?? []) as Array<{ id: string }>).map(role => role.id));
+            const incomingIds = new Set<string>(roles.map(role => role.id));
             const idsToDelete = Array.from(existingIds).filter(id => !incomingIds.has(id));
 
             if (idsToDelete.length > 0) {

--- a/netlify/functions/takeaway/pending.ts
+++ b/netlify/functions/takeaway/pending.ts
@@ -20,7 +20,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const { data, error } = await supabase
-            .from<CommandeRow>('commandes')
+            .from('commandes')
             .select(COMMANDE_SELECT)
             .eq('statut', 'pendiente_validacion')
             .is('table_id', null)
@@ -31,7 +31,8 @@ export default async function handler(request: Request): Promise<Response> {
             return internalError('Unable to retrieve takeaway orders');
         }
 
-        const commandes: Commande[] = (data ?? []).map(mapCommandeRow);
+        const rows = (data ?? []) as CommandeRow[];
+        const commandes: Commande[] = rows.map(mapCommandeRow);
         return jsonResponse(commandes);
     } catch (error) {
         console.error('takeaway/pending: unexpected error', error);

--- a/netlify/functions/takeaway/ready.ts
+++ b/netlify/functions/takeaway/ready.ts
@@ -20,7 +20,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const { data, error } = await supabase
-            .from<CommandeRow>('commandes')
+            .from('commandes')
             .select(COMMANDE_SELECT)
             .eq('statut', 'en_cours')
             .is('table_id', null)
@@ -31,7 +31,8 @@ export default async function handler(request: Request): Promise<Response> {
             return internalError('Unable to retrieve takeaway orders');
         }
 
-        const commandes: Commande[] = (data ?? []).map(mapCommandeRow);
+        const rows = (data ?? []) as CommandeRow[];
+        const commandes: Commande[] = rows.map(mapCommandeRow);
         return jsonResponse(commandes);
     } catch (error) {
         console.error('takeaway/ready: unexpected error', error);

--- a/netlify/functions/takeaway/submit.ts
+++ b/netlify/functions/takeaway/submit.ts
@@ -9,17 +9,18 @@ export const config = { path: '/takeaway/submit' };
 const loadCommande = async (id: string): Promise<Commande> => {
     const supabase = getSupabaseClient();
     const { data, error } = await supabase
-        .from<CommandeRow>('commandes')
+        .from('commandes')
         .select(COMMANDE_SELECT)
         .eq('id', id)
         .maybeSingle();
     if (error) {
         throw new Error(error.message);
     }
-    if (!data) {
+    const row = data as CommandeRow | null;
+    if (!row) {
         throw new Error('Commande not found');
     }
-    return mapCommandeRow(data);
+    return mapCommandeRow(row);
 };
 
 export default async function handler(request: Request): Promise<Response> {

--- a/netlify/functions/time-tracking/entries.ts
+++ b/netlify/functions/time-tracking/entries.ts
@@ -19,7 +19,7 @@ export default async function handler(request: Request): Promise<Response> {
 
     try {
         const { data, error } = await supabase
-            .from<TimeEntry>('time_entries')
+            .from('time_entries')
             .select('*')
             .order('timestamp', { ascending: false });
 
@@ -28,7 +28,8 @@ export default async function handler(request: Request): Promise<Response> {
             return internalError('Unable to retrieve time entries');
         }
 
-        return jsonResponse(data ?? []);
+        const rows = (data ?? []) as TimeEntry[];
+        return jsonResponse(rows);
     } catch (error) {
         console.error('time-tracking/entries: unexpected error', error);
         return internalError();

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -82,13 +82,12 @@ export const api = {
         if (isSupabaseConfigured() && siteAssetsTable) {
             try {
                 const client = getSupabaseClient();
-                const { data, error } = await client
-                    .from<{ key: string; value: string }>(siteAssetsTable)
-                    .select('key, value');
+                const { data, error } = await client.from(siteAssetsTable).select('key, value');
                 if (error) {
                     console.warn('Supabase site asset query failed, falling back to Netlify function.', error);
                 } else if (data) {
-                    return data.reduce<Record<string, string>>((acc, row) => {
+                    const rows = data as Array<{ key: string; value: string }>;
+                    return rows.reduce<Record<string, string>>((acc, row) => {
                         acc[row.key] = row.value;
                         return acc;
                     }, {});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     ],
     "skipLibCheck": true,
     "types": [
-      "node"
+      "node",
+      "vite/client"
     ],
     "moduleResolution": "bundler",
     "isolatedModules": true,


### PR DESCRIPTION
## Summary
- add the Vite env type definitions so import.meta.env resolves during type checking
- update Supabase queries in the Netlify functions to avoid invalid generics and explicitly cast results
- adjust the client-side Supabase site asset fallback to match the new typing approach

## Testing
- npx tsc --noEmit
- npm run build
- npm run check:csp

------
https://chatgpt.com/codex/tasks/task_b_68cedd7caa54832abf99816bf4f4f9c9